### PR TITLE
Move docker registry data to 'docker-registry-config' configmap

### DIFF
--- a/apim-operator/deploy/controller-configs/docker_registry_conf.yaml
+++ b/apim-operator/deploy/controller-configs/docker_registry_conf.yaml
@@ -1,0 +1,26 @@
+#Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: docker-registry-config
+  namespace: wso2-system
+data:
+  #docker registry type which the mgw image to be pushed. supported types: DOCKER_HUB, AMAZON_ECR, GCR, HTTP.   Default->  registryType: DOCKER_HUB
+  registryType: DOCKER_HUB
+  #docker repository name which the mgw image to be pushed.  eg->  repositoryName: docker.io/{USER_NAME of Docker Hub account}
+  repositoryName: REPOSITORY_NAME_OF_DOCKER_REGISTRY

--- a/apim-operator/pkg/controller/api/constants.go
+++ b/apim-operator/pkg/controller/api/constants.go
@@ -52,6 +52,7 @@ const (
 	mgwConfConst         = "micro-gw.conf"
 	controllerConfName   = "controller-config"
 	ingressConfigs       = "ingress-configs"
+	dockerRegConfigs     = "docker-registry-config"
 	ingressProperties    = "ingress.properties"
 	policyFileConst      = "policies.yaml"
 	ingressResourceName  = "ingressResourceName"

--- a/toolkit-docker-image/Dockerfile
+++ b/toolkit-docker-image/Dockerfile
@@ -14,7 +14,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM alpine:3.11
+FROM adoptopenjdk/openjdk8:jdk8u222-b10-alpine
 LABEL maintainer="<dev@wso2.org>"
 
 ENV LANG=C.UTF-8


### PR DESCRIPTION
fix #253 
- Fix overriding err value when getting ingress conf
- Move docker registry data to 'docker-registry-config' configmap
- Change toolkit dockerfile base image
- Related apictl changes: https://github.com/wso2/product-apim-tooling/pull/229