### PR TITLE
Rename registry specific secrets and configmaps

### DIFF
--- a/apim-operator/pkg/registry/amazon_ecr.go
+++ b/apim-operator/pkg/registry/amazon_ecr.go
@@ -54,7 +54,7 @@ var amazonEcr = &Config{
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: utils.ConfigJsonVolume,
+						Name: utils.AmazonCredHelperConfMap,
 					},
 				},
 			},
@@ -63,7 +63,7 @@ var amazonEcr = &Config{
 			Name: AwsCredFileVolume,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: utils.AwsCredentialsVolume,
+					SecretName: utils.AwsCredentialsSecret,
 				},
 			},
 		},

--- a/apim-operator/pkg/registry/dockerhub.go
+++ b/apim-operator/pkg/registry/dockerhub.go
@@ -39,7 +39,7 @@ var dockerHub = &Config{
 			Name: "reg-secret-volume",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: utils.ConfigJsonVolume,
+					SecretName: utils.DockerRegCredSecret,
 					Items: []corev1.KeyToPath{
 						{
 							Key:  utils.DockerConfigKeyConst,
@@ -51,7 +51,7 @@ var dockerHub = &Config{
 		},
 	},
 	ImagePullSecrets: []corev1.LocalObjectReference{
-		{Name: utils.ConfigJsonVolume},
+		{Name: utils.DockerRegCredSecret},
 	},
 }
 

--- a/apim-operator/pkg/registry/gcr.go
+++ b/apim-operator/pkg/registry/gcr.go
@@ -42,7 +42,7 @@ var gcr = &Config{
 			Name: svcAccKeyVolume,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: utils.GcrSvcAccKeyVolume,
+					SecretName: utils.GcrSvcAccKeySecret,
 				},
 			},
 		},
@@ -54,7 +54,7 @@ var gcr = &Config{
 		},
 	},
 	ImagePullSecrets: []corev1.LocalObjectReference{
-		{Name: utils.ConfigJsonVolume},
+		{Name: utils.GcrPullSecret},
 	},
 }
 

--- a/apim-operator/pkg/registry/utils/consts.go
+++ b/apim-operator/pkg/registry/utils/consts.go
@@ -16,8 +16,12 @@
 
 package utils
 
-const ConfigJsonVolume = "config-json"
-const AwsCredentialsVolume = "aws-cred"
-const GcrSvcAccKeyVolume = "gcr-key"
-const GcrSvcAccKeyFile = "gcr_key.json"
 const DockerConfigKeyConst = ".dockerconfigjson"
+const DockerRegCredSecret = "docker-registry-credentials"
+
+const AmazonCredHelperConfMap = "amazon-credential-helper"
+const AwsCredentialsSecret = "aws-credentials"
+
+const GcrSvcAccKeySecret = "google-application-credentials"
+const GcrSvcAccKeyFile = "gcr_key.json"
+const GcrPullSecret = "gcr-pull-secret"


### PR DESCRIPTION
fix wso2/K8s-api-operator#258

- Rename registry specific secrets and configmaps
- Related APICTL changes: https://github.com/wso2/product-apim-tooling/pull/230