### PR TITLE
Check for untagged ECR image to avoid nil pointer panic

### DIFF
--- a/api-operator/pkg/registry/amazon_ecr.go
+++ b/api-operator/pkg/registry/amazon_ecr.go
@@ -94,8 +94,9 @@ var amazonEcr = &Config{
 
 		for _, id := range images.ImageIds {
 			// found the image with tag
-			logger.Info("Found the image tag from the AWS ECR repository", "RegistryId", awsRegistryId, "RepositoryName", awsRepoName, "image", imageName, "tag", tag)
-			if *id.ImageTag == fmt.Sprintf("%s-%s", imageName, tag) {
+			// untagged images 'id.ImageTag' returns nil; check nil before accessing the pointer
+			if id.ImageTag != nil && *id.ImageTag == fmt.Sprintf("%s-%s", imageName, tag) {
+				logger.Info("Found the image tag from the AWS ECR repository", "RegistryId", awsRegistryId, "RepositoryName", awsRepoName, "image", imageName, "tag", tag)
 				return true, nil
 			}
 		}


### PR DESCRIPTION
#### Purpose
- fix #283 - Check this for more info
- Check for untagged ECR image to avoid nil pointer panic in the api-operator.

In any case if there is a untagged image in the repository current setup of the api-operator leads to a nil pointer panic.

Check for the pointer `id.ImageTag` nil and otherwise read the the pointer value `*id.ImageTag`

