### PR TITLE
Update configs and CRDs in how to guide docs

### DIFF
--- a/docs/HowToGuide/OverviewOfCrds/apply-rate-limiting-to-api.md
+++ b/docs/HowToGuide/OverviewOfCrds/apply-rate-limiting-to-api.md
@@ -14,6 +14,12 @@ This policy cofigmap is mounted to kaniko job by the API controller and used to 
 Create a ratelimiting policy using the RateLimiting kind. You can create 3 types of policies with the RateLimiting kind as shown below.
 Include the limit from which you want to throttle the API requests.
 
+Note: When an API refers a ratelimiting policy in swagger definition under x-wso2-throttling-tier keyword you need to make sure that the namespace that you have
+provided the ratelimiting policy is same as the namespace of the API. 
+
+Example: In the following ratelimiting policies the namespace is provided as "wso2-test-ns". Therefore the namespace of the API that these ratelimiting policies are being
+referred should be "wso2-test-ns". 
+
 * Application throttling
 ```
 apiVersion: wso2.com/v1alpha1

--- a/docs/HowToGuide/OverviewOfCrds/apply-security-to-api.md
+++ b/docs/HowToGuide/OverviewOfCrds/apply-security-to-api.md
@@ -1,7 +1,9 @@
 ### Applying security for APIs 
 
 - APIs created with kubernetes apim operator can be secured by defining security with security kind. It supports basic, JWT and Oauth2 security types.
-
+- Note: When a security custom resource refers a secret, you need to make sure the namespace of the secret is same as the namespace of that security custom resource.
+        When an API refers a security custom resource in swagger definition under security keyword you need to make sure that the namespace of the security custom 
+        resource is same as the namespace that the API belongs to. 
 #### Securing API with JWT authentication
    
 1. Create a secret with the certificate
@@ -10,12 +12,14 @@
    >> kubectl create secret generic <SECRET_NAME> -n <NAMESPACE> --from-file=<PATH_TO_CERT>
    ```
   
+  - The namespace of the secret should be the namespace of the security custom resource.  
 1. Create a security with security kind. Include the name of the secret created in step (1) in certificate field
    ```yaml
    apiVersion: <VERSION>
    kind: Security
    metadata:
      name: <SECURITY_NAME>
+     namespace: <NAMESPACE>
    spec:
      type: JWT
      securityConfig:
@@ -23,14 +27,13 @@
          audience:  <AUDIENCE>
          certificate: <NAME_OF_THE_SECRET_CREATED_IN_STEP_1>
    ```
-
 #### Securing API with Oauth2 authentication
 
 1. Create a secret with the certificate
    ```sh
    >> kubectl create secret generic <SECRET_NAME> -n <NAMESPACE> --from-file=<PATH_TO_CERT>
    ```
-   
+   - The namespace of the secret should be the namespace of the security custom resource.
 1. Create a secret with user credentials 
    ```yaml
    apiVersion: v1
@@ -42,7 +45,7 @@
      username: <BASE64_ENCODED_USER_NAME>
      password: <BASE64_ENCODED_PASSWORD>
    ```  
-
+   
 1. Create a security with security kind. Include the name of the secret created in step (1) in certificate field and name of the secret created in step (2) in credentials field.
    ```yaml
    apiVersion: <VERSION>
@@ -77,8 +80,8 @@
    apiVersion: <version>
    kind: Security
    metadata:
-     name: <security name>
-     namespace: <namespace>
+     name: <SECURITY_NAME>
+     namespace: <NAMESPACE>
    spec:
      type: basic
      securityConfig:

--- a/docs/HowToGuide/configurations-overview.md
+++ b/docs/HowToGuide/configurations-overview.md
@@ -59,7 +59,11 @@
 
 - API Operator provides the security to your API. You need to define the security which needs to be applied on the API under "security" extension in the API.
 
-- But if you have not specified the security in the API definition, the API operator will apply the default security for the API.
+- At the time of the installation of the API Operator the default security will be applied. If you need to change the default security configurations either you can edit the security custom resource or you can edit the file within the distribution.
+
+- If you need to apply the same security configurations to all the APIs then you need to change the default security configurations. If you prefer any other security type as the default security type, you may need to change the values of the default security configuration. 
+
+- The security policy does not need to be mentioned in the swagger and the default security configurations will be applied automatically. 
 
 - Default security configurations are in the ***api-operator/controller-configs/default_security_cr.yaml*** file.
 
@@ -88,7 +92,11 @@
       server.pem: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlEcVRDQ0FwR2dBd0lCQWdJRVhiQUJvekFOQmdrcWhraUc5dzBCQVFzRkFEQmtNUXN3Q1FZRFZRUUdFd0pWDQpVekVMTUFrR0ExVUVDQXdDUTBFeEZqQVVCZ05WQkFjTURVMXZkVzUwWVdsdUlGWnBaWGN4RFRBTEJnTlZCQW9NDQpCRmRUVHpJeERUQUxCZ05WQkFzTUJGZFRUekl4RWpBUUJnTlZCQU1NQ1d4dlkyRnNhRzl6ZERBZUZ3MHhPVEV3DQpNak13TnpNd05ETmFGdzB5TWpBeE1qVXdOek13TkROYU1HUXhDekFKQmdOVkJBWVRBbFZUTVFzd0NRWURWUVFJDQpEQUpEUVRFV01CUUdBMVVFQnd3TlRXOTFiblJoYVc0Z1ZtbGxkekVOTUFzR0ExVUVDZ3dFVjFOUE1qRU5NQXNHDQpBMVVFQ3d3RVYxTlBNakVTTUJBR0ExVUVBd3dKYkc5allXeG9iM04wTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGDQpBQU9DQVE4QU1JSUJDZ0tDQVFFQXhlcW9aWWJRL1NyOERPRlErL3FiRWJDcDZWemI1aHpIN29hM2hmMkZaeFJLDQpGMEg2YjhDT016ejgrMG12RWRZVnZiLzMxak1FTDJDSVFoa1FSb2wxSXJ1RDZuQk9ta2p1WEpTQmZpY2tsTWFKDQpaT1JodUNyQjRyb0h4em9HMTlhV21zY0EwZ25mQktvMm9HWFNqSm1uWnhJaCsyWDZzeUhDZnlNWlowMEx6RHlyDQpnb1hXUVh5RnZDQTJheDU0czdzS2lIT00zUDRBOVc0UVV3bW9FaTRIUW1QZ0pqSU00ZUdWUGgwR3RJQU5OK0JPDQpRMUtrVUk3T3p0ZUhDVEx1M1ZqeE0wc3c4UVJheVpkaG5pUEYrVTluM2ZhMW1PNEtMQnNXNG1ETGpnOFIvSnVBDQpHVFgvU0VFR2owQjVIV1FBUDZteXhLRnoyeHdEYUNHdlQrcmR2a2t0T3dJREFRQUJvMk13WVRBVUJnTlZIUkVFDQpEVEFMZ2dsc2IyTmhiR2h2YzNRd0hRWURWUjBPQkJZRUZFRHBMQjRQRGd6c2R4RDJGVjNyVm5Pci9BMERNQjBHDQpBMVVkSlFRV01CUUdDQ3NHQVFVRkJ3TUJCZ2dyQmdFRkJRY0RBakFMQmdOVkhROEVCQU1DQlBBd0RRWUpLb1pJDQpodmNOQVFFTEJRQURnZ0VCQUU4SC9heEFnWGp0OTNIR0NZR3VtVUxXMmxLa2dxRXZYcnlQMlFrUnBieVFTc1RZDQpjTDdaTFNWQjdNVlZIdElzSGg4ZjFDNFhxNlF1OE5VcnF1NVpMQzFwVUJ5YXFSMlpJemNqL09XTEdZUmpTVEhTDQpWbVZJcTlRcUJxMWo3cjZmM0JXcWFPSWlrbm1UekV1cUlWbE9UWTBnTytTSGRTNjJ2cjJGQ3o0eU9yQkV1bEdBDQp2b21zVThzcWc0UGhGbmtoeEk0TTkxMkx5KzJSZ045TDdBa2h6SytFelhZMS9RdGxJL1Z5c05mUzZ6ckhhc0t6DQo2Q3JLS0NHcVFuQm5TdlNUeUY5T1I1S0ZIbmtBd0U5OTVJWnJjU1FpY014c0xoVE1VSERMUS9nUnl5N1YvWnBEDQpNZkFXUis1T2VRaU5BcC9iRzRmakpvVGRvcWt1bDUxKzJiSEhWclU9DQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tDQo=
     type: Opaque
      ```
-
+    - If you have changed the default security custom resource then you need to re apply it after doing the modifications using the following command
+    ```sh
+   >> apictl apply -f <k8s-api-operator-home>/api-operator/deploy/controller-configs/default_security_cr.yaml
+     ```
+    - If you have distinct security policies for different APIs you need to create multiple security policies with the required properties.
     - If you prefer any other security type as the default security type, you may need to change the above values.
     - For more information refer [how to define security guide](../HowToGuide/OverviewOfCrds/apply-security-to-api.md)
     


### PR DESCRIPTION
This PR includes the following changes to how to guide docs:

- how to configure the default security modifications
- update the apply rate limiting and security docs with related to defining the namespace