### PR TITLE
Fix JWT token config indentation

### DIFF
--- a/api-operator/deploy/controller-configs/mgw_conf_mustache.yaml
+++ b/api-operator/deploy/controller-configs/mgw_conf_mustache.yaml
@@ -116,11 +116,11 @@ data:
     # JWT token authorization configurations. You can provide multiple JWT issuers
     {{range .JwtConfigs}}
     [[jwtTokenConfig]]
-    issuer = "{{.Issuer}}"
-    audience = "{{.Audience}}"
-    certificateAlias = "{{.CertificateAlias}}"
-    # Validate subscribed APIs
-    validateSubscription = {{.ValidateSubscription}}
+      issuer = "{{.Issuer}}"
+      audience = "{{.Audience}}"
+      certificateAlias = "{{.CertificateAlias}}"
+      # Validate subscribed APIs
+      validateSubscription = {{.ValidateSubscription}}
     {{end}}
 
     # JWT token revocation configurations


### PR DESCRIPTION
Fix JWT token config indentation
fix wso2/k8s-api-operator#366