### PR TITLE
Update MGW toolkit image version and ReadMe.md file

### DIFF
--- a/toolkit-docker-image/Dockerfile
+++ b/toolkit-docker-image/Dockerfile
@@ -30,7 +30,7 @@ ARG JMS_MODULE_PATH=/root/.ballerina
 
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2am-micro-gw-toolkit-linux
-ARG WSO2_SERVER_VERSION=3.1.0
+ARG WSO2_SERVER_VERSION=3.2.0-alpha
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://github.com/wso2/product-microgateway/releases/download/v${WSO2_SERVER_VERSION}/${WSO2_SERVER}.zip

--- a/toolkit-docker-image/ReadMe.md
+++ b/toolkit-docker-image/ReadMe.md
@@ -1,13 +1,22 @@
-### Creating MGW-ToolKit Image <br>
-Note that the root directory is called \<dockerfile-home>
+# Creating MGW-ToolKit Image
 
-1. Create a directory called "files" in \<dockerfile-home>
-2. Place relevant Java distribution and MGW toolkit distribution in the "files" directory (unzipped)
-3. Change the mgw toolkit version in the Dockerfile.
-4. Place the Dockerfile in \<dockerfile-home>
-5. Execute the following command to build the Dockerfile <br>
->        docker build -t wso2am/<toolkit name and version for the image name>
->        eg: docker build -t wso2am/wso2am-micro-gw-toolkit-3.0.1 .
-6. Pushing the built dockerimage to docker registry <br>
->        docker push wso2am/<toolkit name and version for the image name>
->        docker push wso2am/wso2am-micro-gw-toolkit-3.0.1
+1. Change the mgw toolkit version (i.e. ARG `WSO2_SERVER_VERSION`) in the Dockerfile.
+    ```dockerfile
+    ARG WSO2_SERVER_VERSION=3.2.0
+    ```
+
+1. Execute the following command to build the docker image from Dockerfile.
+    ```sh
+    >> docker build -t wso2am/wso2micro-gw-toolkit:<TOOLKIT_VERSION> .
+    
+    # example:
+    >> docker build -t wso2am/wso2micro-gw-toolkit:3.2.0 .
+    ```
+
+1. Push the built docker image to docker registry.
+    ```sh
+    >> docker push wso2am/wso2micro-gw-toolkit:<TOOLKIT_VERSION>
+    
+    # example:
+    >> docker push wso2am/wso2micro-gw-toolkit:3.2.0
+    ```


### PR DESCRIPTION
- Update MGW toolkit image version
- Update toolkit ReadMe.md file (preview: https://github.com/renuka-fernando/k8s-api-operator/blob/mgw-toolkit-320-alpha/toolkit-docker-image/ReadMe.md)
- Pushed the image `wso2am/wso2micro-gw-toolkit:3.2.0-alpha`