### PR TITLE
Adding API Key feature

### DIFF
--- a/api-operator/deploy/controller-configs/controller_conf.yaml
+++ b/api-operator/deploy/controller-configs/controller_conf.yaml
@@ -98,12 +98,8 @@ data:
   apiKeyIssuerCertificateAlias: "ballerina"
   validityTime: "-1"
   #Provide the list of allowed APIs by the generated API Key
-  #allowedAPIs: |
-    #API name given in the API Definition: Allowed versions
   allowedAPIs: |
-    Petstore-Apikey: v1, v2, v3
-    Petstore-Apikeyy: v4
-
+  # - API name given in the API Definition: Allowed versions
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/api-operator/deploy/controller-configs/controller_conf.yaml
+++ b/api-operator/deploy/controller-configs/controller_conf.yaml
@@ -89,6 +89,20 @@ data:
   #Request and response validation
   enableRequestValidation: "false"
   enableResponseValidation: "false"
+  #APIKey issuer configurations
+  #APIKey STS token configurations
+  enabledAPIKeyIssuer: "true"
+  apiKeyKeystorePath: "${mgw-runtime.home}/runtime/bre/security/ballerinaKeystore.p12"
+  apiKeyKeystorePassword: "ballerina"
+  apiKeyIssuerName: "https://localhost:9095/apikey"
+  apiKeyIssuerCertificateAlias: "ballerina"
+  validityTime: "-1"
+  #Provide the list of allowed APIs by the generated API Key
+  #allowedAPIs: |
+    #API name given in the API Definition: Allowed versions
+  allowedAPIs: |
+    Petstore-Apikey: v1, v2, v3
+    Petstore-Apikeyy: v4
 
 ---
 apiVersion: v1

--- a/api-operator/deploy/controller-configs/mgw_conf_mustache.yaml
+++ b/api-operator/deploy/controller-configs/mgw_conf_mustache.yaml
@@ -113,6 +113,7 @@ data:
           clientId = ""
           clientSecret = ""
 
+
     # JWT token authorization configurations. You can provide multiple JWT issuers
     {{range .JwtConfigs}}
     [[jwtTokenConfig]]
@@ -215,6 +216,31 @@ data:
       ciphers="TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256, TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_DSS_WITH_AES_128_CBC_SHA256, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA, TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA, TLS_DHE_DSS_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256  ,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256, TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_DSS_WITH_AES_128_GCM_SHA256  ,TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,SSL_RSA_WITH_3DES_EDE_CBC_SHA, TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA, SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA,TLS_EMPTY_RENEGOTIATION_INFO_SCSV"
       # The type of client certificate verification. (e.g.: "require" or "optional")
       sslVerifyClient = "optional"
+
+    # API Key authentication configurations
+    {{range .APIKeyConfigs}}
+    [apikey.tokenConfigs]
+      issuer = "{{.APIKeyIssuer}}"
+      certificateAlias = "{{.APIKeyCertificateAlias}}"
+      audience = "{{.APIKeyAudience}}"
+      # Validate Allowed/subscribed APIs
+      validateAllowedAPIs = {{.ValidateAllowedAPIs}}
+    {{end}}
+
+    [apikey.issuer]
+      # API Key STS token configurations
+      [apikey.issuer.tokenConfig]
+        enabled = {{$.EnabledAPIKeyIssuer}}
+        keyStorePath = "{{$.APIKeyKeystorePath}}"
+        keyStorePassword = "{{$.APIKeyKeystorePassword}}"
+        issuer = "{{$.APIKeyIssuerName}}"
+        certificateAlias = "{{$.APIKeyIssuerCertificateAlias}}"
+        validityTime = {{$.ValidityTime}}
+        {{range .APIKeyAllowedAPIs}}
+        [[apikey.issuer.api]]
+          name = "{{.AllowedAPIName}}"
+          versions = "{{.AllowedAPIVersions}}"
+        {{end}}
 
     # Throttling configurations
     [throttlingConfig]

--- a/api-operator/deploy/controller-configs/mgw_conf_mustache.yaml
+++ b/api-operator/deploy/controller-configs/mgw_conf_mustache.yaml
@@ -236,10 +236,12 @@ data:
         issuer = "{{$.APIKeyIssuerName}}"
         certificateAlias = "{{$.APIKeyIssuerCertificateAlias}}"
         validityTime = {{$.ValidityTime}}
-        {{range .APIKeyAllowedAPIs}}
+        {{range $allowedAPI := .APIKeyAllowedAPIs}}
+          {{range $allowedAPIName, $allowedAPIVersions := $allowedAPI}}
         [[apikey.issuer.api]]
-          name = "{{.AllowedAPIName}}"
-          versions = "{{.AllowedAPIVersions}}"
+          name = "{{$allowedAPIName}}"
+          versions = "{{$allowedAPIVersions}}"
+          {{end}}
         {{end}}
 
     # Throttling configurations

--- a/api-operator/deploy/crds/wso2_v1alpha1_security_crd.yaml
+++ b/api-operator/deploy/crds/wso2_v1alpha1_security_crd.yaml
@@ -1,24 +1,15 @@
-#Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-#
-# WSO2 Inc. licenses this file to you under the Apache License,
-# Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: securities.wso2.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.type
+    name: SECURITY_TYPE
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: AGE
+    type: date
   group: wso2.com
   names:
     kind: Security
@@ -60,9 +51,9 @@ spec:
                     type: string
                   issuer:
                     type: string
-                  validateSubscription:
-                    type: boolean
                   validateAllowedAPIs:
+                    type: boolean
+                  validateSubscription:
                     type: boolean
                 type: object
               type: array
@@ -82,11 +73,3 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
-  additionalPrinterColumns:
-  - name: SECURITY_TYPE
-    type: string
-    JSONPath: .spec.type
-  - name: AGE
-    type: date
-    JSONPath: .metadata.creationTimestamp
-

--- a/api-operator/deploy/crds/wso2_v1alpha1_security_crd.yaml
+++ b/api-operator/deploy/crds/wso2_v1alpha1_security_crd.yaml
@@ -62,6 +62,8 @@ spec:
                     type: string
                   validateSubscription:
                     type: boolean
+                  validateAllowedAPIs:
+                    type: boolean
                 type: object
               type: array
             type:
@@ -80,3 +82,11 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+  additionalPrinterColumns:
+  - name: SECURITY_TYPE
+    type: string
+    JSONPath: .spec.type
+  - name: AGE
+    type: date
+    JSONPath: .metadata.creationTimestamp
+

--- a/api-operator/deploy/crds/wso2_v1alpha1_security_crd.yaml
+++ b/api-operator/deploy/crds/wso2_v1alpha1_security_crd.yaml
@@ -1,3 +1,19 @@
+#Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/api-operator/pkg/apis/wso2/v1alpha1/security_types.go
+++ b/api-operator/pkg/apis/wso2/v1alpha1/security_types.go
@@ -45,6 +45,8 @@ type SecurityStatus struct {
 
 // Security is the Schema for the securities API
 // +k8s:openapi-gen=true
+// +kubebuilder:printcolumn:name="SECURITY_TYPE",type=string,JSONPath=`.spec.type`
+// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=`.metadata.creationTimestamp`
 type Security struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api-operator/pkg/apis/wso2/v1alpha1/security_types.go
+++ b/api-operator/pkg/apis/wso2/v1alpha1/security_types.go
@@ -70,6 +70,7 @@ type SecurityConfig struct {
 	Issuer               string `json:"issuer"`
 	Audience             string `json:"audience"`
 	ValidateSubscription bool   `json:"validateSubscription,omitempty"`
+	ValidateAllowedAPIs  bool   `json:"validateAllowedAPIs,omitempty"`
 }
 
 func init() {

--- a/api-operator/pkg/controller/api/api_controller.go
+++ b/api-operator/pkg/controller/api/api_controller.go
@@ -259,16 +259,16 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 			return reconcile.Result{}, securityErr
 		}
 
-		securityDefinition, jwtConfArray, errSec := security.Handle(&r.client, securityMap, userNamespace, secSchemeDefined)
+		securityDefinition, jwtConfArray, apiKeyConfArray,errSec := security.Handle(&r.client, securityMap, userNamespace, secSchemeDefined)
 		if errSec != nil {
 			return reconcile.Result{}, errSec
 		}
 		mgw.Configs.JwtConfigs = jwtConfArray
+		mgw.Configs.APIKeyConfigs = apiKeyConfArray
 		//adding security scheme to swagger
 		if len(securityDefinition) > 0 {
 			swaggerDoc.Components.Extensions[swagger.SecuritySchemeExtension] = securityDefinition
 		}
-
 		// mount formatted swagger to kaniko job
 		formattedSwagger := swagger.PrettyString(swaggerDoc)
 		formattedSwaggerCmName := swaggerCmName + "-mgw"

--- a/api-operator/pkg/controller/security/security_controller.go
+++ b/api-operator/pkg/controller/security/security_controller.go
@@ -117,8 +117,8 @@ func (r *ReconcileSecurity) Reconcile(request reconcile.Request) (reconcile.Resu
 	if strings.EqualFold(instance.Spec.Type, "JWT") {
 		for _, securityConfig := range instance.Spec.SecurityConfig {
 			if securityConfig.Issuer == "" || securityConfig.Audience == "" {
-				reqLogger.Info("Required fields are missing")
-				return reconcile.Result{}, nil
+				reqLogger.Error(err, "Required fields are missing")
+				return reconcile.Result{}, err
 			}
 			certificateSecret := &corev1.Secret{}
 			errcertificate := r.client.Get(context.TODO(), types.NamespacedName{Name: securityConfig.Certificate, Namespace: userNamespace}, certificateSecret)
@@ -133,8 +133,8 @@ func (r *ReconcileSecurity) Reconcile(request reconcile.Request) (reconcile.Resu
 	if strings.EqualFold(instance.Spec.Type, "apiKey") {
 		for _, securityConfig := range instance.Spec.SecurityConfig {
 			if securityConfig.Issuer == "" || securityConfig.Audience == "" || securityConfig.Alias == "" {
-				reqLogger.Info("Required fields are missing")
-				return reconcile.Result{}, nil
+				reqLogger.Error(err, "Required fields are missing")
+				return reconcile.Result{}, err
 			}
 		}
 	}
@@ -142,8 +142,8 @@ func (r *ReconcileSecurity) Reconcile(request reconcile.Request) (reconcile.Resu
 	if strings.EqualFold(instance.Spec.Type, "Oauth") {
 		for _, securityConfig := range instance.Spec.SecurityConfig {
 			if securityConfig.Credentials == "" || securityConfig.Endpoint == "" {
-				reqLogger.Info("required fields are missing")
-				return reconcile.Result{}, nil
+				reqLogger.Error(err, "Required fields are missing")
+				return reconcile.Result{}, err
 			}
 			credentialSecret := &corev1.Secret{}
 			errcertificate := r.client.Get(context.TODO(), types.NamespacedName{Name: securityConfig.Credentials, Namespace: userNamespace}, credentialSecret)
@@ -159,8 +159,8 @@ func (r *ReconcileSecurity) Reconcile(request reconcile.Request) (reconcile.Resu
 	if strings.EqualFold(instance.Spec.Type, "Basic") {
 		for _, securityConfig := range instance.Spec.SecurityConfig {
 			if securityConfig.Credentials == "" {
-				reqLogger.Info("required field credentials are missing")
-				return reconcile.Result{}, nil
+				reqLogger.Error(err, "Required fields are missing")
+				return reconcile.Result{}, err
 			}
 		}
 	}

--- a/api-operator/pkg/controller/security/security_controller.go
+++ b/api-operator/pkg/controller/security/security_controller.go
@@ -130,6 +130,15 @@ func (r *ReconcileSecurity) Reconcile(request reconcile.Request) (reconcile.Resu
 		}
 	}
 
+	if strings.EqualFold(instance.Spec.Type, "apiKey") {
+		for _, securityConfig := range instance.Spec.SecurityConfig {
+			if securityConfig.Issuer == "" || securityConfig.Audience == "" || securityConfig.Alias == "" {
+				reqLogger.Info("Required fields are missing")
+				return reconcile.Result{}, nil
+			}
+		}
+	}
+
 	if strings.EqualFold(instance.Spec.Type, "Oauth") {
 		for _, securityConfig := range instance.Spec.SecurityConfig {
 			if securityConfig.Credentials == "" || securityConfig.Endpoint == "" {

--- a/api-operator/pkg/mgw/config.go
+++ b/api-operator/pkg/mgw/config.go
@@ -58,13 +58,13 @@ const (
 	logLevelConst                       = "logLevel"
 	httpPortConst                       = "httpPort"
 	httpsPortConst                      = "httpsPort"
-	enabledAPIKeyIssuerConst			= "enabledAPIKeyIssuer"
-	apiKeyKeystorePathConst				= "apiKeyKeystorePath"
-	apiKeyKeystorePasswordConst			= "apiKeyKeystorePassword"
-	apiKeyIssuerNameConst				= "apiKeyIssuerName"
-	apiKeyIssuerCertificateAliasConst	= "apiKeyIssuerCertificateAlias"
-	validityTimeConst					= "validityTime"
-	allowedAPIsConst					= "allowedAPIs"
+	enabledAPIKeyIssuerConst            = "enabledAPIKeyIssuer"
+	apiKeyKeystorePathConst             = "apiKeyKeystorePath"
+	apiKeyKeystorePasswordConst         = "apiKeyKeystorePassword"
+	apiKeyIssuerNameConst               = "apiKeyIssuerName"
+	apiKeyIssuerCertificateAliasConst   = "apiKeyIssuerCertificateAlias"
+	validityTimeConst                   = "validityTime"
+	allowedAPIsConst                    = "allowedAPIs"
 )
 
 type Configuration struct {
@@ -117,12 +117,12 @@ type Configuration struct {
 	LogLevel string
 
 	//APIKeyIssuerConfig
-	EnabledAPIKeyIssuer				string
-	APIKeyKeystorePath				string
-	APIKeyKeystorePassword			string
-	APIKeyIssuerName				string
-	APIKeyIssuerCertificateAlias	string
-	ValidityTime					int32
+	EnabledAPIKeyIssuer          string
+	APIKeyKeystorePath           string
+	APIKeyKeystorePassword       string
+	APIKeyIssuerName             string
+	APIKeyIssuerCertificateAlias string
+	ValidityTime                 int32
 
 	// APIKeyTokenConfig
 	APIKeyConfigs *[]APIKeyTokenConfig
@@ -139,10 +139,10 @@ type JwtTokenConfig struct {
 }
 
 type APIKeyTokenConfig struct {
-	APIKeyCertificateAlias	string
-	APIKeyIssuer			string
-	APIKeyAudience			string
-	ValidateAllowedAPIs		bool
+	APIKeyCertificateAlias string
+	APIKeyIssuer           string
+	APIKeyAudience         string
+	ValidateAllowedAPIs    bool
 }
 
 type APIKeyTokenAllowedAPIs []map[string]string
@@ -205,20 +205,20 @@ var Configs = &Configuration{
 	LogLevel: "INFO",
 
 	//APIKeyIssuerConfig
-	EnabledAPIKeyIssuer:			"true",
-	APIKeyKeystorePath:				"${mgw-runtime.home}/runtime/bre/security/ballerinaKeystore.p12",
-	APIKeyKeystorePassword:			"ballerina",
-	APIKeyIssuerName:				"https://localhost:9095/apikey",
-	APIKeyIssuerCertificateAlias:	"ballerina",
-	ValidityTime:					-1,
+	EnabledAPIKeyIssuer:          "true",
+	APIKeyKeystorePath:           "${mgw-runtime.home}/runtime/bre/security/ballerinaKeystore.p12",
+	APIKeyKeystorePassword:       "ballerina",
+	APIKeyIssuerName:             "https://localhost:9095/apikey",
+	APIKeyIssuerCertificateAlias: "ballerina",
+	ValidityTime:                 -1,
 
 	// APIKeyTokenConfig
 	APIKeyConfigs: &[]APIKeyTokenConfig{
 		{
-			APIKeyCertificateAlias:	"ballerina",
-			APIKeyIssuer:			"https://localhost:9095/apikey",
+			APIKeyCertificateAlias: "ballerina",
+			APIKeyIssuer:           "https://localhost:9095/apikey",
 			APIKeyAudience:         "http://org.wso2.apimgt/gateway",
-			ValidateAllowedAPIs:	false,
+			ValidateAllowedAPIs:    false,
 		},
 	},
 }
@@ -259,8 +259,8 @@ func SetApimConfigs(client *client.Client) error {
 		Configs.ValidityTime = int32(validityTime)
 	}
 	var apiKeyTokenIssuerAPIs APIKeyTokenAllowedAPIs
-	 _ = yaml.Unmarshal([]byte(apimConfig.Data[allowedAPIsConst]), &apiKeyTokenIssuerAPIs)
-	 logConf.Info("API KEY", "apiKeyTokenAPIS", apiKeyTokenIssuerAPIs)
+	_ = yaml.Unmarshal([]byte(apimConfig.Data[allowedAPIsConst]), &apiKeyTokenIssuerAPIs)
+	logConf.Info("API KEY", "apiKeyTokenAPIS", apiKeyTokenIssuerAPIs)
 	Configs.APIKeyAllowedAPIs = apiKeyTokenIssuerAPIs
 	httpPort, err := strconv.Atoi(apimConfig.Data[httpPortConst])
 	if err != nil {

--- a/api-operator/pkg/mgw/config.go
+++ b/api-operator/pkg/mgw/config.go
@@ -59,12 +59,12 @@ const (
 	httpPortConst                       = "httpPort"
 	httpsPortConst                      = "httpsPort"
 	enabledAPIKeyIssuerConst			= "enabledAPIKeyIssuer"
-    apiKeyKeystorePathConst       		= "apiKeyKeystorePath"
+	apiKeyKeystorePathConst				= "apiKeyKeystorePath"
 	apiKeyKeystorePasswordConst			= "apiKeyKeystorePassword"
 	apiKeyIssuerNameConst				= "apiKeyIssuerName"
 	apiKeyIssuerCertificateAliasConst	= "apiKeyIssuerCertificateAlias"
 	validityTimeConst					= "validityTime"
-	allowedAPIsConst 					= "allowedAPIs"
+	allowedAPIsConst					= "allowedAPIs"
 )
 
 type Configuration struct {
@@ -117,12 +117,12 @@ type Configuration struct {
 	LogLevel string
 
 	//APIKeyIssuerConfig
-	EnabledAPIKeyIssuer 		 string
-	APIKeyKeystorePath 			 string
-	APIKeyKeystorePassword 		 string
-	APIKeyIssuerName 			 string
-	APIKeyIssuerCertificateAlias string
-	ValidityTime 				 int32
+	EnabledAPIKeyIssuer				string
+	APIKeyKeystorePath				string
+	APIKeyKeystorePassword			string
+	APIKeyIssuerName				string
+	APIKeyIssuerCertificateAlias	string
+	ValidityTime					int32
 
 	// APIKeyTokenConfig
 	APIKeyConfigs *[]APIKeyTokenConfig
@@ -205,20 +205,20 @@ var Configs = &Configuration{
 	LogLevel: "INFO",
 
 	//APIKeyIssuerConfig
-	EnabledAPIKeyIssuer: 		  "true",
-	APIKeyKeystorePath: 	      "${mgw-runtime.home}/runtime/bre/security/ballerinaKeystore.p12",
-	APIKeyKeystorePassword:       "ballerina",
-	APIKeyIssuerName: 			  "https://localhost:9095/apikey",
-	APIKeyIssuerCertificateAlias: "ballerina",
-	ValidityTime: 				   -1,
+	EnabledAPIKeyIssuer:			"true",
+	APIKeyKeystorePath:				"${mgw-runtime.home}/runtime/bre/security/ballerinaKeystore.p12",
+	APIKeyKeystorePassword:			"ballerina",
+	APIKeyIssuerName:				"https://localhost:9095/apikey",
+	APIKeyIssuerCertificateAlias:	"ballerina",
+	ValidityTime:					-1,
 
 	// APIKeyTokenConfig
 	APIKeyConfigs: &[]APIKeyTokenConfig{
 		{
-			APIKeyCertificateAlias: "ballerina",
-			APIKeyIssuer:           "https://localhost:9095/apikey",
+			APIKeyCertificateAlias:	"ballerina",
+			APIKeyIssuer:			"https://localhost:9095/apikey",
 			APIKeyAudience:         "http://org.wso2.apimgt/gateway",
-			ValidateAllowedAPIs:    false,
+			ValidateAllowedAPIs:	false,
 		},
 	},
 }

--- a/api-operator/pkg/security/const.go
+++ b/api-operator/pkg/security/const.go
@@ -24,6 +24,9 @@ const (
 	basicSecurityAndScheme = "basic"
 	jwtConst               = "JWT"
 	oauthConst             = "Oauth"
+	apiKeyConst            = "apiKey"
+	apiKeyIn			   = "header"
+	apiKeyName			   = "api_key"
 )
 
 const (

--- a/scenarios/scenario-19/README.md
+++ b/scenarios/scenario-19/README.md
@@ -1,0 +1,127 @@
+## Scenario 19 - Deploy petstore service as a managed API secured with API Key Authentication
+- This scenario describes how to deploy the petstore service(https://petstore.swagger.io/v2) on a kubernetes cluster as a managed API secured with API key authentication. Hence the API invocation will be done with an API key only.  
+- The WSO2 API Microgateway expects a self-contained JWT as an API Key.
+- First we will deploy Security custom resource(CR) according to API key security related configurations. 
+- Security CR created in the previous step should be referred in the Swagger definition using security extension.
+- When API refers the Security CR in swagger definition under security keyword you need to make sure that the namespace of the Security CR is same as the namespace that the API belongs to.
+- Then swagger definition will be deployed in the Kubernetes cluster as a managed API. 
+ 
+
+ ***Important:***
+> Follow the main README and deploy the api-operator and configuration files. Make sure to set the analyticsEnabled to "true" and deploy analytics secret with credentials to analytics server and certificate, if you want to check analytics.
+
+ #### Secure APIs using API key Authentication
+ ##### API Key Security Token Service Configuration
+
+- API Key Security Token Service can be configured in the apim-config in `controller-configs/controller_conf.yaml`
+    ```
+    #APIKey issuer configurations
+    #APIKey STS token configurations
+    enabledAPIKeyIssuer: "true"
+    apiKeyKeystorePath: "${mgw-runtime.home}/runtime/bre/security/ballerinaKeystore.p12"
+    apiKeyKeystorePassword: "ballerina"
+    apiKeyIssuerName: "https://localhost:9095/apikey"
+    apiKeyIssuerCertificateAlias: "ballerina"
+    validityTime: "-1"
+    allowedAPIs: |
+      Petstore-Apikey: v1, v2, v3
+    ```
+- You can configure the validity you can configure a validity period for the API key token in validityTime. The default value is -1 which indicates unlimited time. 
+
+- You can provide the list of allowed APIs by the generated API Key.
+  ```
+  allowedAPIs: |
+    API name given in the API Definition: Allowed versions of that API
+  ```
+- Apply the changes
+   ```$xslt
+    >> apictl apply -f <k8s-api-operator-home>/api-operator/controller-artifacts/controller_conf.yaml
+    ```
+ ##### Defining security schemes
+
+- Security schemes can be defined on the swagger definition under securitySchemes. One or more API key security schemes can be used (as in logical OR) at the same time. A unique name for "name", query or header for "in"  and apiKey as "type" needs to be given for the defined API Key security scheme.
+
+- If a security scheme is not defined it will use the default security scheme, "api_key" as the name of the header.
+
+ ##### Deploying the artifacts
+ 
+- Navigate to scenarios/scenario-19 directory.
+
+- In the API key Security custom resource you can configure validateAllowedAPIs as true or false. If it is true when validating the API Key token, it only validates the allowed APIs of the API Key token which were provided in the controller_conf.yaml under allowedAPIs.
+
+- Deploy the API key Security custom resource.
+    ```$xslt
+    >> apictl apply -f apiKey-security.yaml
+    
+    Output:
+    security.wso2.com/petstoreapikey created
+    ```
+
+- Prepared petstore swagger definition can be found within this directory.
+
+- Security schema of the API is referred in the swagger file with the "security" extension.
+In this swagger definition, the security schema of the "petstore" service has been mentioned as follows.
+    ```
+    security:
+      - petstoreapikey: []
+    ```
+    This can be referred either in the root level of the swagger(globally) or under resources such that the defined security will be reflected only for a specific resource.
+- Execute the following to expose pet-store as a managed API.
+
+- Deploy the  API <br /> 
+    ```
+    >> apictl add api -n petstore-apikey --from-file=swagger.yaml --override
+    
+    Output:
+    creating configmap with swagger definition
+    configmap/petstore-apikey-swagger created
+    api.wso2.com/petstore-apikey created
+    ```
+    Note: ***--override*** flag is used to you want to rebuild the API image even if it exists in the configured docker repository
+    
+- Get available API <br /> 
+    ```
+    >> apictl get apis
+    
+    Output:
+    NAME              AGE
+    petstore-apikey   53m
+    ```
+
+- Get service details to invoke the API. (Please wait until the external-IP is populated in the corresponding service)
+    ```
+    >> apictl get services
+    
+    Output:
+    NAME              TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)                         AGE
+    petstore-apikey   LoadBalancer   10.8.15.95   104.198.161.233   9095:32367/TCP,9090:30323/TCP   53m
+
+    ```
+    - You can see petstore service has been exposed as a managed API.
+    - Get the external IP of the managed API's service
+ 
+- Obtain the API key token using the following command. <br />
+
+    ```
+    TOKEN=$(curl -X get "https://<EXTERNAL-IP>:9095/apikey" -H "Authorization:Basic YWRtaW46YWRtaW4=" -k)
+    ```
+- Invoking the API <br />
+    ```
+    >> curl -X GET "https://<EXTERNAL-IP of LB service>:9095/petstoreapikey/v1/pet/5" -H "accept: application/xml" -H "api_key:$TOKEN" -k
+    ```
+    - Once you execute the above command, it will call to the managed API, which then call its endpoint(https://petstore.swagger.io/v2). If the request is success, you would be able to see the response as below.
+        ```
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?><Pet><category><id>55</id><name>string</name></category><id>55</id><name>SRC_TIME_SIZE</name><photoUrls><photoUrl>string</photoUrl></photoUrls><status>available</status><tags><tag><id>55</id><name>string</name></tag></tags></Pet>
+        ```
+    - If the token is invalid or if the token is expired it will give an error response as below.
+       ```
+       {"fault":{"code":900901, "message":"Invalid Credentials", "description":"Invalid Credentials. Make sure you have given the correct access token"}}
+       ```
+- Delete the  API <br /> 
+    - Following command will delete all the artifacts created with this API including pods, deployment and services.
+    ```
+    >> apictl delete api petstore-apikey
+    
+    Output:
+    api.wso2.com "petstore-apikey" deleted
+    ```

--- a/scenarios/scenario-19/README.md
+++ b/scenarios/scenario-19/README.md
@@ -24,14 +24,14 @@
     apiKeyIssuerCertificateAlias: "ballerina"
     validityTime: "-1"
     allowedAPIs: |
-      Petstore-Apikey: v1, v2, v3
+      - Petstore-Apikey: v1, v2, v3
     ```
 - You can configure the validity you can configure a validity period for the API key token in validityTime. The default value is -1 which indicates unlimited time. 
 
 - You can provide the list of allowed APIs by the generated API Key.
   ```
   allowedAPIs: |
-    API name given in the API Definition: Allowed versions of that API
+    - API name given in the API Definition: Allowed versions of that API
   ```
 - Apply the changes
    ```$xslt

--- a/scenarios/scenario-19/apiKey-security.yaml
+++ b/scenarios/scenario-19/apiKey-security.yaml
@@ -17,45 +17,6 @@
 apiVersion: wso2.com/v1alpha1
 kind: Security
 metadata:
-  name: petstoreoauth
-spec:
-  # Security - Oauth2
-  type: Oauth
-  securityConfig:
-    - certificate: wso2am310-secret #create secret with certificate and add secret name
-      endpoint: "https://wso2apim.wso2:9443"
-      credentials: oauth-credentials
-
----
-apiVersion: wso2.com/v1alpha1
-kind: Security
-metadata:
-  name: petstorebasic
-spec:
-  # Security - Basic
-  type: basic
-  securityConfig:
-    - credentials: secret-basic
-
----
-apiVersion: wso2.com/v1alpha1
-kind: Security
-metadata:
-  name: petstorejwt
-spec:
-  # Security - JWT
-  type: JWT
-  securityConfig:
-    - issuer: https://wso2apim:32001/oauth2/token
-      audience: http://org.wso2.apimgt/gateway
-      #create secret with certificate and add secret name
-      certificate: wso2am310-secret
-      validateSubscription: false
-
----
-apiVersion: wso2.com/v1alpha1
-kind: Security
-metadata:
   name: petstoreapikey
 spec:
   # Security - APIKey

--- a/scenarios/scenario-19/swagger.yaml
+++ b/scenarios/scenario-19/swagger.yaml
@@ -1,0 +1,189 @@
+#Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+openapi: 3.0.0
+servers:
+  - url: https://petstore.swagger.io/v2
+  - url: http://petstore.swagger.io/v2
+info:
+  description: 'This is a sample server Petstore server.  You can find out more about
+    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For
+    this sample, you can use the api key `special-key` to test the authorization filters.'
+  version: v1
+  title: Petstore-Apikey
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+x-wso2-basePath: /petstoreapikey/{version}
+x-wso2-production-endpoints:
+  urls:
+    - https://petstore.swagger.io/v2
+paths:
+  "/pet/findByStatus":
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+              default: available
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+        '400':
+          description: Invalid status value
+  "/pet/{petId}":
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      security:
+        - petstoreapikey: []
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+components:
+  schemas:
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Category
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          "$ref": "#/components/schemas/Category"
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            "$ref": "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/Pet"
+        application/xml:
+          schema:
+            "$ref": "#/components/schemas/Pet"
+      description: Pet object that needs to be added to the store
+      required: true


### PR DESCRIPTION
## Purpose
> Adding API Key support for K8S operator

## Approach
> 

- Introduced Configurations related to API key issuer in the controller_conf.yaml under apim-config.
- API key validation related configurations need to be included in the security custom resource.
- Security CR created should be referred in the Swagger definition using security extension.

## User stories
> When an user needs to deploy a service on a kubernetes cluster as a managed API secured with API key authentication. 

## Test environment
> 

- go version go1.14.2 linux/amd64
- Ubuntu 18.04.4 LTS