### PR TITLE
Improving information related to APIs by adding events

### DIFF
--- a/api-operator/pkg/controller/api/api_controller.go
+++ b/api-operator/pkg/controller/api/api_controller.go
@@ -73,7 +73,13 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("api-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New(
+		"api-controller", 
+		mgr,
+		controller.Options{
+			MaxConcurrentReconciles: 10,
+			Reconciler: r},
+	)
 	if err != nil {
 		return err
 	}

--- a/api-operator/pkg/controller/api/constants.go
+++ b/api-operator/pkg/controller/api/constants.go
@@ -33,6 +33,8 @@ const (
 	routeMode                     = "Route"
 	observabilityEnabledConfigKey = "observabilityEnabled"
 
+	eventTypeError	=	"Error"
+
 	ingressHostName   = "ingressHostName"
 	routeHost         = "routeHost"
 

--- a/api-operator/pkg/interceptors/interceptors.go
+++ b/api-operator/pkg/interceptors/interceptors.go
@@ -38,7 +38,7 @@ func Handle(client *client.Client, instance *wso2v1alpha1.API) error {
 	// handle ballerina interceptors
 	balFound, err := handle(client, &instance.Spec.Definition.Interceptors.Ballerina, instance.Namespace, balIntPath)
 	if err != nil {
-		logger.Error(err, "Error handling Ballerina interceptors")
+		logger.Error(err, "Error handling Ballerina interceptors", "namespace", instance.Namespace, "apiName", instance.Name)
 		return err
 	}
 	kaniko.DocFileProp.BalInterceptorsFound = balFound
@@ -46,7 +46,7 @@ func Handle(client *client.Client, instance *wso2v1alpha1.API) error {
 	// handle java interceptors
 	javaFound, err := handle(client, &instance.Spec.Definition.Interceptors.Java, instance.Namespace, javaIntPath)
 	if err != nil {
-		logger.Error(err, "Error handling Java interceptors")
+		logger.Error(err, "Error handling Java interceptors", "namespace", instance.Namespace, "apiName", instance.Name)
 		return err
 	}
 	kaniko.DocFileProp.JavaInterceptorsFound = javaFound

--- a/api-operator/pkg/kaniko/docker.go
+++ b/api-operator/pkg/kaniko/docker.go
@@ -75,14 +75,16 @@ func HandleDockerFile(client *client.Client, userNamespace, apiName string, owne
 	dockerFileConfMap := k8s.NewConfMap()
 	err := k8s.Get(client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: dockerFileTemplate}, dockerFileConfMap)
 	if err != nil {
-		logDocker.Error(err, "Error retrieving docker template configmap", "configmap", dockerFileTemplate)
+		logDocker.Error(err, "Error retrieving docker template configmap",
+			"configmap", dockerFileTemplate, "namespace", userNamespace, "apiName", apiName)
 		return err
 	}
 
 	// get file name in configmap
 	fileName, err := maps.OneKey(dockerFileConfMap.Data)
 	if err != nil {
-		logDocker.Error(err, "Error retrieving docker template filename", "configmap_data", dockerFileConfMap.Data)
+		logDocker.Error(err, "Error retrieving docker template filename",
+			"configmap_data", dockerFileConfMap.Data, "namespace", userNamespace, "apiName", apiName)
 		return err
 	}
 

--- a/api-operator/pkg/mgw/api.go
+++ b/api-operator/pkg/mgw/api.go
@@ -17,16 +17,18 @@
 package mgw
 
 import (
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
+
+var logEp = logf.Log.WithName("endpoint.value")
 
 func ExternalIP (client *client.Client, apiInstance *wso2v1alpha1.API, operatorMode string, svc *corev1.Service,
 	ingressConfData map[string]string, openshiftConfData map[string]string) string {
 
-	var log = logf.Log.WithName("endpoint value")
+	logger := logEp.WithValues("namespace", apiInstance.Namespace, "apiName", apiInstance.Name)
 	var ip string
 	if operatorMode == "default" {
 		loadBalancerFound := svc.Status.LoadBalancer.Ingress
@@ -35,26 +37,26 @@ func ExternalIP (client *client.Client, apiInstance *wso2v1alpha1.API, operatorM
 			ip += elem.IP
 		}
 		apiInstance.Spec.ApiEndPoint = ip
-		log.Info("IP value is :" + ip)
-		log.Info("ENDPOINT value in default mode is ","apiEndpoint",apiInstance.Spec.ApiEndPoint)
+		logger.Info("IP value is :" + ip)
+		logger.Info("ENDPOINT value in default mode is ","apiEndpoint",apiInstance.Spec.ApiEndPoint)
 	}
 	if operatorMode == "ingress" {
 		ingressHostConf := ingressConfData[ingressHostName]
-		log.Info("Host Name is :" + ingressHostConf)
+		logger.Info("Host Name is :" + ingressHostConf)
 		apiInstance.Spec.ApiEndPoint = ingressHostConf
-		log.Info("ENDPOINT value in ingress mode is","apiEndpoint",apiInstance.Spec.ApiEndPoint)
+		logger.Info("ENDPOINT value in ingress mode is","apiEndpoint",apiInstance.Spec.ApiEndPoint)
 		ip = "<pending>"
 	}
 	if operatorMode == "route" {
 		routeHostConf := openshiftConfData[routeHost]
-		log.Info("Host Name is :" + routeHostConf)
+		logger.Info("Host Name is :" + routeHostConf)
 		apiInstance.Spec.ApiEndPoint = routeHostConf
-		log.Info("ENDPOINT value in route mode is","apiEndpoint",apiInstance.Spec.ApiEndPoint)
+		logger.Info("ENDPOINT value in route mode is","apiEndpoint",apiInstance.Spec.ApiEndPoint)
 		ip = "<pending>"
 	}
 	if apiInstance.Spec.ApiEndPoint == "" {
 		apiInstance.Spec.ApiEndPoint = "<pending>"
-		log.Info("ENDPOINT value after updating is","apiEndpoint" ,apiInstance.Spec.ApiEndPoint)
+		logger.Info("ENDPOINT value after updating is","apiEndpoint" ,apiInstance.Spec.ApiEndPoint)
 	}
 
 	return ip

--- a/api-operator/pkg/mgw/ingress.go
+++ b/api-operator/pkg/mgw/ingress.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 )
 
-var logIng = log.Log.WithName("mgw.ingress")
+var loggerIng = log.Log.WithName("mgw.ingress")
 
 const (
 	ingressConfigs       = "ingress-configs"
@@ -44,6 +44,7 @@ const (
 // ApplyIngressResource creates or updates an Ingress resource to expose mgw
 // Supports for multiple apiBasePaths when there are multiple swaggers for one API CRD
 func ApplyIngressResource(client *client.Client, api *wso2v1alpha1.API, apiBasePathMap map[string]string, owner *[]metav1.OwnerReference) error {
+	logIng := loggerIng.WithValues("namespace", api.Namespace, "apiName", api.Name)
 	ingressConfMap := k8s.NewConfMap()
 	err := k8s.Get(client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: ingressConfigs}, ingressConfMap)
 	if err != nil {

--- a/api-operator/pkg/mgw/route.go
+++ b/api-operator/pkg/mgw/route.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 )
 
-var logRoute = log.Log.WithName("mgw.route")
+var loggerRoute = log.Log.WithName("mgw.route")
 
 const (
 	openShiftConfigs = "route-configs"
@@ -49,6 +49,7 @@ const (
 // Supports for multiple apiBasePaths when there are multiple swaggers for one API CRD
 func ApplyRouteResource(client *client.Client, api *wso2v1alpha1.API,
 	apiBasePathMap map[string]string, owner *[]metav1.OwnerReference) error {
+	logRoute := loggerRoute.WithValues("namespace", api.Namespace, "apiName", api.Name)
 	routeConfMap := k8s.NewConfMap()
 	errRoute := k8s.Get(client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: openShiftConfigs}, routeConfMap)
 	if errRoute != nil {


### PR DESCRIPTION
#### Purpose
This PR,

1. Improves the information returned by `kubectl describe apis` command by adding events related to the specific API resource. This is done by introducing an event recorder to the api-controller which will send custom events to the relevant resource.
Related issue - https://github.com/wso2/k8s-api-operator/issues/334
However, the events will be removed after 1 hour by the garbage collector in Kubernetes.

```
$ kubectl describe apis petstore-api

Events:
  Type    Reason            Age                From            Message
  ----    ------            ----               ----            -------
  Normal  Configs           15m (x3 over 18m)  api-controller  Creating swagger configmap for MGW.
  Normal  Configs           15m (x3 over 18m)  api-controller  Handling analytics & interceptors, rendering dockerfile & mgw configs, and creating the Kaniko job.
  Normal  KanikoJob         15m (x3 over 18m)  api-controller  Deploying kaniko job.
  Normal  KanikoJob         15m (x3 over 17m)  api-controller  Kaniko job completed successfully.
  Normal  MGWRuntime        15m (x3 over 17m)  api-controller  Deploying MGW runtime: petstore-api.
  Normal  MGWService        15m (x3 over 17m)  api-controller  Creating MGW service: petstore-api.
  Normal  MGWservice        15m (x2 over 15m)  api-controller  Managed API service endpoint: 35.224.76.103
  Normal  Deploy            15m (x2 over 15m)  api-controller  Successfully deployed the API: petstore-api.
```

2. Fixes an issue where reconciler is re-queued infinitely when LoadBalancer type is used with Minikube clusters.

3. Changes the controller logic to create concurrent reconcilers.


#### Suggested Labels
Improvement