### PR TITLE
Update docs for 1.2.0 alpha release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 ## Introduction
 
-As microservices are increasingly being deployed on Kubernetes, the need to expose these microservices as well documented, easy to consume, managed APIs is becoming important to develop great applications. The API operator for Kubernetes makes APIs a first-class citizen in the Kubernetes ecosystem. Similar to deploying microservices, you can now use this operator to deploy APIs for individual microservices or compose several microservices into individual APIs. With this users will be able to expose their microservice as managed API in Kubernetes environment without any additional work.
+As microservices are increasingly being deployed on Kubernetes, the need to expose these microservices as well
+documented, easy to consume, managed APIs is becoming important to develop great applications.
+The API operator for Kubernetes makes APIs a first-class citizen in the Kubernetes ecosystem.
+Similar to deploying microservices, you can now use this operator to deploy APIs for individual microservices or
+compose several microservices into individual APIs. With this users will be able to expose their microservice
+as managed API in Kubernetes environment without any additional work.
 
 
 ![Alt text](docs/images/K8s-API-Operator.png?raw=true "K8s API Operator")
@@ -30,7 +35,8 @@ In this document, we will walk through on the following.
 
 - An account in DockerHub or private docker registry
 
-- Download [k8s-api-operator-1.2.0-alpha.zip](https://github.com/wso2/k8s-api-operator/releases/download/v1.2.0-alpha/k8s-api-operator-1.2.0-alpha.zip) and extract the zip
+- Download [k8s-api-operator-1.2.0-alpha.zip](https://github.com/wso2/k8s-api-operator/releases/download/v1.2.0-alpha/k8s-api-operator-1.2.0-alpha.zip)
+and extract the zip
 
     1. This zip contains the artifacts that required to deploy in Kubernetes.
     2. Extract k8s-api-operator-1.2.0-alpha.zip
@@ -46,7 +52,8 @@ In this document, we will walk through on the following.
 #### Step 1: Deploy a sample microservice in Kubernetes
 
 
-- Let’s deploy a sample microservice in K8s which lists the details of products. This will deploy a pod and service for the sample service.
+- Let’s deploy a sample microservice in K8s which lists the details of products.
+This will deploy a pod and service for the sample service.
 
     ```sh
     >> kubectl apply -f scenarios/scenario-1/products_dep.yaml
@@ -69,7 +76,8 @@ In this document, we will walk through on the following.
     <details><summary>If you are using Minikube click here</summary>
     <p>
     
-    **_Note:_**  By default API operator requires the LoadBalancer service type which is not supported in Minikube by default. Here is how you can enable it on Minikube.
+    **_Note:_**  By default API operator requires the LoadBalancer service type which is not supported in Minikube
+    by default. Here is how you can enable it on Minikube.
     
     - On Minikube, the LoadBalancer type makes the Service accessible through the minikube service command.
     
@@ -91,7 +99,13 @@ In this document, we will walk through on the following.
     >> curl -X GET http://<EXTERNAL_IP>:80/products
          
     Output:
-    {"products":[{"name":"Apples", "id":101, "price":"$1.49 / lb"}, {"name":"Macaroni & Cheese", "id":151, "price":"$7.69"}, {"name":"ABC Smart TV", "id":301, "price":"$399.99"}, {"name":"Motor Oil", "id":401, "price":"$22.88"}, {"name":"Floral Sleeveless Blouse", "id":501, "price":"$21.50"}]}
+    {"products":[
+        {"name":"Apples", "id":101, "price":"$1.49 / lb"},
+        {"name":"Macaroni & Cheese", "id":151, "price":"$7.69"},
+        {"name":"ABC Smart TV", "id":301, "price":"$399.99"},
+        {"name":"Motor Oil", "id":401, "price":"$22.88"},
+        {"name":"Floral Sleeveless Blouse", "id":501, "price":"$21.50"}
+    ]}
     ```
    
     ```sh
@@ -211,10 +225,11 @@ API image.
     wso2apim   NodePort   10.0.39.192   <none>        8280:32004/TCP,8243:32003/TCP,9763:32002/TCP,9443:32001/TCP   114s
     ```
 
-    **_Note:_** To access the API portal, add host mapping entry to the /etc/hosts file. As we have exposed the API portal service in Node Port type, you can use the IP address of any Kubernetes node.
+    **_Note:_** To access the API portal, add host mapping entry to the /etc/hosts file. As we have exposed
+    the API portal service in Node Port type, you can use the IP address of any Kubernetes node.
     
     ```
-    <Any K8s Node IP>  wso2apim
+    <ANY_K8S_NODE_IPP>  wso2apim
     ```
     
     - For Docker for Mac use "127.0.0.1" for the K8s node IP
@@ -231,7 +246,8 @@ API image.
 
 #### Step 5: Expose the sample microservice as a managed API
 
-Let’s deploy an API for our microservice. The Open API definition of the API can be found in the scenario/scenario-1/products-swagger.yaml.
+Let’s deploy an API for our microservice. The Open API definition of the API can be found in
+the scenario/scenario-1/products-swagger.yaml.
 
 The endpoint of our microservice is referred in the API definition.
 
@@ -255,18 +271,23 @@ The endpoint of our microservice is referred in the API definition.
     --namespace=wso2      Namespace to deploy the API
     --override            Overwrite the docker image creation for already created docker image
     
-    >> apictl add api -n <API_NAME> --from-file=<LOCATION_TO_THE_OPEN_API_DEFINITION> --replicas=<NUMBER_OF_REPLICAS> --namespace=<DESIRED_NAMESPACE>
+    >> apictl add api -n <API_NAME> --from-file=<LOCATION_TO_THE_OPEN_API_DEFINITION> \
+        --replicas=<NUMBER_OF_REPLICAS> \
+        --namespace=<DESIRED_NAMESPACE>
     ```
 
-    **_Note:_** Namespace and replicas are optional parameters. If they are not provided, the default namespace will be used and 1 replica will be created. 
+    **_Note:_** Namespace and replicas are optional parameters. If they are not provided, the default namespace
+    will be used and 1 replica will be created. 
 
-    When you deploy the API, it will first run the Kaniko job. This basically builds the docker image of the API and pushes it to Docker-Hub. 
+    When you deploy the API, it will first run the Kaniko job. This basically builds the docker image of the API
+    and pushes it to Docker-Hub. 
 
     Once the Kaniko job is completed, it will deploy the managed API for your microservice.
 
 - Verify the API deployment
 
-    If you list down the pods immediately after the add API command you will only see the pod related to Kaniko job. Once it is completed you will see the deployed API. If you are on Minikube, this might take several minutes.
+    If you list down the pods immediately after the add API command you will only see the pod related to Kaniko job.
+    Once it is completed you will see the deployed API. If you are on Minikube, this might take several minutes.
 
     ```sh
     >> apictl get pods 
@@ -303,7 +324,8 @@ The endpoint of our microservice is referred in the API definition.
 
 - Retrieve the API service endpoint details
 
-    The API service is exposed as the Load Balancer service type. You can get the API service endpoint details by using the following command.
+    The API service is exposed as the Load Balancer service type. You can get the API service endpoint details by using
+    the following command.
 
     ```sh
     >> apictl get services
@@ -316,7 +338,8 @@ The endpoint of our microservice is referred in the API definition.
     <details><summary>If you are using Minikube click here</summary>
     <p>
     
-    **_Note:_**  By default API operator requires the LoadBalancer service type which is not supported in Minikube by default. Here is how you can enable it on Minikube.
+    **_Note:_**  By default API operator requires the LoadBalancer service type which is not supported in Minikube
+    by default. Here is how you can enable it on Minikube.
     
     - On Minikube, the LoadBalancer type makes the Service accessible through the minikube service command.
     
@@ -342,7 +365,13 @@ The endpoint of our microservice is referred in the API definition.
     You will get an error as below.
     
     ```json
-    {"fault":{"code":900902, "message":"Missing Credentials", "description":"Missing Credentials. Make sure your API invocation call has a header: \"Authorization\""}}
+    {
+        "fault": {
+            "code": 900902,
+            "message": "Missing Credentials",
+            "description": "Missing Credentials. Make sure your API invocation call has a header: \"Authorization\""
+        }
+    }
     ```
     
     Since the API is secured now, you are experiencing the above error. Hence you need a valid access token to invoke the API.
@@ -370,7 +399,8 @@ The endpoint of our microservice is referred in the API definition.
     >> curl -X GET "https://35.232.188.134:9095/store/v1.0.0/products/101" -H "Authorization:Bearer $TOKEN" -k
     ```
     
-    **_Note:_** In a production-level scenario, there should be a way to discover the available services and obtain an access token in a secured manner. For this, we need to push this API to API Portal and get an OAuth 2.0 access token
+    **_Note:_** In a production-level scenario, there should be a way to discover the available services and obtain
+    an access token in a secured manner. For this, we need to push this API to API Portal and get an OAuth 2.0 access token
 
 
 <br />
@@ -378,13 +408,16 @@ The endpoint of our microservice is referred in the API definition.
 #### Step 7: Pushing the API to the API Portal
 
 
-To make the API discoverable for other users and get the access tokens, we need to push the API to the API portal. Then the app developers/subscribers can navigate to the devportal (https://wso2apim:32001/devportal) to perform the following actions.
+To make the API discoverable for other users and get the access tokens, we need to push the API to the API portal.
+Then the app developers/subscribers can navigate to the devportal (https://wso2apim:32001/devportal)
+to perform the following actions.
 
 - Create an application
 - Subscribe the API to the application
 - Generate a JWT access token 
 
-The following commands will help you to push the API to the API portal in Kubernetes. Commands of the API Controller can be found [here](https://github.com/wso2/product-apim-tooling/blob/v3.1.0/import-export-cli/docs/apictl.md) 
+The following commands will help you to push the API to the API portal in Kubernetes.
+Commands of the API Controller can be found [here](https://github.com/wso2/product-apim-tooling/blob/v3.1.0/import-export-cli/docs/apictl.md) 
 
 
 - Add the API portal as an environment to the API controller using the following command.
@@ -422,7 +455,8 @@ The following commands will help you to push the API to the API portal in Kubern
 
 #### Step 8: Generate an access token for the API
 
-- By default the API is secured with JWT. Hence a valid JWT token is needed to invoke the API. You can obtain a JWT token using the API Controller command as below.
+- By default the API is secured with JWT. Hence a valid JWT token is needed to invoke the API.
+You can obtain a JWT token using the API Controller command as below.
     
     ```sh
     >> apictl set --token-type JWT
@@ -452,7 +486,8 @@ You can find the documentation [here](docs/Readme.md).
 
 ### Cleanup
 
-Execute the following commands if you wish to clean up the Kubernetes cluster by removing all the applied artifacts and configurations related to API operator and API portal.
+Execute the following commands if you wish to clean up the Kubernetes cluster by removing all the applied artifacts
+and configurations related to API operator and API portal.
 
 ```sh
 >> apictl delete api online-store

--- a/README.md
+++ b/README.md
@@ -125,11 +125,13 @@ In this document, we will walk through on the following.
     ```sh
     export WSO2_API_OPERATOR_VERSION=v1.2.0-alpha
     ```
-- Execute the following command to install API Operator interactively and configure repository to push the microgateway image.
+- Execute the following command to install API Operator interactively and configure repository to push the built managed
+API image.
 - Select "Docker Hub" as the repository type.
 - Enter repository name of your Docker Hub account (usually it is the username as well).
-- Enter username and the password
-- Confirm configuration are correct with entering "Y"
+  - Supports both `jennifer` and `docker.io/jennifer` (backward compatibility) as repository name.
+- Enter username and the password.
+- Confirm configuration are correct with entering "Y".
 
     ```sh
     >> apictl install api-operator
@@ -141,11 +143,11 @@ In this document, we will walk through on the following.
     5: HTTPS Private Registry
     6: Quay.io
     Choose a number: 1: 1
-    Enter repository name: docker.io/jennifer
+    Enter repository name: jennifer
     Enter username: jennifer
     Enter password: *******
     
-    Repository: docker.io/jennifer
+    Repository: jennifer
     Username  : jennifer
     Confirm configurations: Y: Y
     ```

--- a/README.md
+++ b/README.md
@@ -30,16 +30,16 @@ In this document, we will walk through on the following.
 
 - An account in DockerHub or private docker registry
 
-- Download [k8s-api-operator-1.1.0.zip](https://github.com/wso2/k8s-api-operator/releases/download/v1.1.0/k8s-api-operator-1.1.0.zip) and extract the zip
+- Download [k8s-api-operator-1.2.0-alpha.zip](https://github.com/wso2/k8s-api-operator/releases/download/v1.2.0-alpha/k8s-api-operator-1.2.0-alpha.zip) and extract the zip
 
     1. This zip contains the artifacts that required to deploy in Kubernetes.
-    2. Extract k8s-api-operator-1.1.0.zip
+    2. Extract k8s-api-operator-1.2.0-alpha.zip
     
     ```
-    cd k8s-api-operator-1.1.0
+    cd k8s-api-operator-1.2.0-alpha
     ```
  
-    **_Note:_** You need to run all commands from within the ***k8s-api-operator-1.1.0*** directory.
+    **_Note:_** You need to run all commands from within the ***k8s-api-operator-1.2.0-alpha*** directory.
 
 <br />
 
@@ -121,6 +121,10 @@ In this document, we will walk through on the following.
 
 #### Step 3: Install API Operator
 
+- Set the operator version as `v1.2.0-alpha` by executing following in a terminal.
+    ```sh
+    export WSO2_API_OPERATOR_VERSION=v1.2.0-alpha
+    ```
 - Execute the following command to install API Operator interactively and configure repository to push the microgateway image.
 - Select "Docker Hub" as the repository type.
 - Enter repository name of your Docker Hub account (usually it is the username as well).

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ In this document, we will walk through on the following.
     1. This zip contains the artifacts that required to deploy in Kubernetes.
     2. Extract k8s-api-operator-1.2.0-alpha.zip
     
-    ```
-    cd k8s-api-operator-1.2.0-alpha
+    ```sh
+    >> cd k8s-api-operator-1.2.0-alpha
     ```
  
     **_Note:_** You need to run all commands from within the ***k8s-api-operator-1.2.0-alpha*** directory.
@@ -62,7 +62,7 @@ In this document, we will walk through on the following.
     >> kubectl get services products
   
     Output:
-    NAME       TYPE           CLUSTER-IP    EXTERNAL-IP       PORT(S)        AGE
+    NAME       TYPE           CLUSTER-IP    EXTERNAL_IP       PORT(S)        AGE
     products   LoadBalancer   10.83.1.131   104.197.114.248   80:30475/TCP   27m
     ```
 
@@ -78,7 +78,7 @@ In this document, we will walk through on the following.
         >> minikube service products --url
         ```
         
-        The IP you receive from above output can be used as the "external-IP" in the following command.
+        The IP you receive from above output can be used as the "EXTERNAL_IP" in the following command.
     
     </p>
     </details>
@@ -88,14 +88,14 @@ In this document, we will walk through on the following.
 
 - To test the microservice, execute the following commands.
     ```sh
-    >> curl -X GET http://<EXTERNAL-IP>:80/products
+    >> curl -X GET http://<EXTERNAL_IP>:80/products
          
     Output:
     {"products":[{"name":"Apples", "id":101, "price":"$1.49 / lb"}, {"name":"Macaroni & Cheese", "id":151, "price":"$7.69"}, {"name":"ABC Smart TV", "id":301, "price":"$399.99"}, {"name":"Motor Oil", "id":401, "price":"$22.88"}, {"name":"Floral Sleeveless Blouse", "id":501, "price":"$21.50"}]}
     ```
    
     ```sh
-    >> curl -X GET http://<EXTERNAL-IP>:80/products/101
+    >> curl -X GET http://<EXTERNAL_IP>:80/products/101
          
     Output:
     {"name":"Apples", "id":101, "price":"$1.49 / lb", "reviewScore":"0", "stockAvailability":false}
@@ -134,12 +134,14 @@ In this document, we will walk through on the following.
     ```sh
     >> apictl install api-operator
     Choose registry type:
-    1: Docker Hub (Or others, quay.io, HTTPS registry)
+    1: Docker Hub
     2: Amazon ECR
     3: GCR
     4: HTTP Private Registry
+    5: HTTPS Private Registry
+    6: Quay.io
     Choose a number: 1: 1
-    Enter repository name (docker.io/john | quay.io/mark | 10.100.5.225:5000/jennifer): docker.io/jennifer
+    Enter repository name: docker.io/jennifer
     Enter username: jennifer
     Enter password: *******
     
@@ -321,7 +323,7 @@ The endpoint of our microservice is referred in the API definition.
         >> minikube service online-store --url
         ```
         
-        The IP you receive from above output can be used as the "external-IP" in the following command.
+        The IP you receive from above output can be used as the "EXTERNAL_IP" in the following command.
     
     </p>
     </details>
@@ -332,7 +334,7 @@ The endpoint of our microservice is referred in the API definition.
 
     Let’s observe what happens if you try to invoke the API as a regular microservice.
     ```sh
-    >> curl -X GET "https://<EXTERNAL-IP>:9095/store/v1.0.0/products" -k
+    >> curl -X GET "https://<EXTERNAL_IP>:9095/store/v1.0.0/products" -k
     ```
     
     You will get an error as below.
@@ -355,7 +357,7 @@ The endpoint of our microservice is referred in the API definition.
     ```sh
     Format: 
     
-    >> curl -X GET "https://<EXTERNAL-IP>:9095/<API-context>/<API-resource>"  -H "Authorization:Bearer $TOKEN" -k
+    >> curl -X GET "https://<EXTERNAL_IP>:9095/<API-context>/<API-resource>"  -H "Authorization:Bearer $TOKEN" -k
     ```
 
     Example commands:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This will deploy a pod and service for the sample service.
     >> kubectl get services products
   
     Output:
-    NAME       TYPE           CLUSTER-IP    EXTERNAL_IP       PORT(S)        AGE
+    NAME       TYPE           CLUSTER-IP    EXTERNAL-IP       PORT(S)        AGE
     products   LoadBalancer   10.83.1.131   104.197.114.248   80:30475/TCP   27m
     ```
 
@@ -118,9 +118,7 @@ This will deploy a pod and service for the sample service.
 
 #### Step 2: Configure API Controller
 
-- Download API controller v3.1.0 or the latest v3.1.x from the [API Manager Tooling web site](https://wso2.com/api-management/tooling/)
-    
-    - Under Dev-Ops Tooling section, you can download the tool based on your operating system.
+- Download [API controller v3.2.0-beta](https://github.com/wso2/product-apim-tooling/releases/tag/v3.2.0-beta).
 
 - Extract the API controller distribution and navigate inside the extracted folder using the command-line tool
 
@@ -137,7 +135,7 @@ This will deploy a pod and service for the sample service.
 
 - Set the operator version as `v1.2.0-alpha` by executing following in a terminal.
     ```sh
-    export WSO2_API_OPERATOR_VERSION=v1.2.0-alpha
+    >> export WSO2_API_OPERATOR_VERSION=v1.2.0-alpha
     ```
 - Execute the following command to install API Operator interactively and configure repository to push the built managed
 API image.
@@ -183,30 +181,16 @@ API image.
 
 #### Step 4: Install the API portal and security token service
 
-[WSO2AM Kubernetes Operator](https://github.com/wso2/k8s-wso2am-operator) is used to deploy API portal and security token service. 
-
-- Install the WSO2AM Operator in Kubernetes.
-
-    ```sh
-    >> apictl install wso2am-operator
-    
-    namespace/wso2-system created
-    serviceaccount/wso2am-pattern-1-svc-account created
-    ...
-    configmap/wso2am-p1-apim-2-conf created
-    configmap/wso2am-p1-mysql-dbscripts created
-    [Setting to K8s Mode]
-    ```
-
 - Install API Portal and security token service under a namespace called "wso2"
 
     ```sh
-    >> apictl apply -f k8s-artifacts/wso2am-operator/api-portal/
+    >> apictl apply -f k8s-artifacts/api-portal/
     
     Output:
     namespace/wso2 created
     configmap/apim-conf created
-    apimanager.apim.wso2.com/custom-pattern-1 created
+    deployment.apps/wso2apim created
+    service/wso2apim created
     ```
 
 - Access API Portal and security token service
@@ -215,21 +199,21 @@ API image.
     >> apictl get pods -n wso2
     
     Output:
-    NAME                                                        READY   STATUS    RESTARTS   AGE
-    all-in-one-api-manager-5694f99754-4zhpq                     1/1     Running   0          2m39s
+    NAME                        READY   STATUS    RESTARTS   AGE
+    wso2apim-596f9d5ff6-mcch6   1/1     Running   0          5m7s
         
     >> apictl get services -n wso2
     
     Output:
-    NAME       TYPE       CLUSTER-IP    EXTERNAL-IP   PORT(S)                                                       AGE
-    wso2apim   NodePort   10.0.39.192   <none>        8280:32004/TCP,8243:32003/TCP,9763:32002/TCP,9443:32001/TCP   114s
+    NAME       TYPE       CLUSTER-IP     EXTERNAL-IP   PORT(S)                                                       AGE
+    wso2apim   NodePort   10.96.209.21   <none>        8280:32004/TCP,8243:32003/TCP,9763:32002/TCP,9443:32001/TCP   5m24s
     ```
 
     **_Note:_** To access the API portal, add host mapping entry to the /etc/hosts file. As we have exposed
     the API portal service in Node Port type, you can use the IP address of any Kubernetes node.
     
     ```
-    <ANY_K8S_NODE_IPP>  wso2apim
+    <ANY_K8S_NODE_IP>  wso2apim
     ```
     
     - For Docker for Mac use "127.0.0.1" for the K8s node IP
@@ -260,7 +244,8 @@ The endpoint of our microservice is referred in the API definition.
     
     Output:
     creating configmap with swagger definition
-    configmap/online-store-swagger created
+    configmap/online-store-1-swagger created
+    creating API definition
     api.wso2.com/online-store created
     ```
 
@@ -446,6 +431,7 @@ Commands of the API Controller can be found [here](https://github.com/wso2/produ
     </br>
     
     ```sh
+    >> apictl login k8s -k
     >> apictl import-api -f online-store/ -e k8s -k
     
     Output:
@@ -490,9 +476,11 @@ Execute the following commands if you wish to clean up the Kubernetes cluster by
 and configurations related to API operator and API portal.
 
 ```sh
+>> apictl remove env k8s
+>> apictl set --mode k8s
 >> apictl delete api online-store
->> apictl remove-env -e k8s
->> apictl delete -f k8s-artifacts/wso2am-operator/api-portal/
+>> apictl delete -f scenarios/scenario-1/products_dep.yaml
+>> apictl delete -f k8s-artifacts/api-portal/
 >> apictl uninstall api-operator
 ```
 

--- a/api-operator/README.md
+++ b/api-operator/README.md
@@ -1,36 +1,40 @@
-#### Developer Guide
+## Developer Guide
 
-**Building the image**
+### Build from source
 
-The api-operator was built using the operator-sdk CLI tool. You can follow the [user guide][operator_sdk_user_guide] of operator-sdk CLI tool for 
+The api-operator was built using the operator-sdk CLI (version v0.17.1) tool. You can follow the [user guide][operator_sdk_user_guide] of operator-sdk CLI tool for 
 more information. 
 
 You should build the image when changes are added to the project. The steps to build the image are listed below. 
 
 1.  After modifying the *_types.go files run the following command to update the generated code for that resource type
+    ```sh
+    >> operator-sdk generate k8s
+    >> operator-sdk generate crds
     ```
-    operator-sdk generate k8s
-    ```
-2.  Build the api-operator image 
-    ```
-    operator-sdk build wso2/k8s-api-operator:v1.1.0
-    ```
-3.  Replace the image name in deploy/controller-artifacts/operator.yaml:
 
-4.  Push it to a registry:
+1.  Build the api-operator image 
+    ```sh
+    >> operator-sdk build wso2/k8s-api-operator:v1.2.0-alpha
     ```
-    docker push wso2/api-operator:v0.6
+
+1.  Replace the image name in deploy/controller-artifacts/operator.yaml:
+
+1.  Push it to a registry:
+    ```sh
+    >> docker push wso2/api-operator:v1.2.0-alpha
     ```
-    
-**Additional Commands**
+
+### Add new API and controller
 
 1. Adding new custom resource definition
-    ```
-    operator-sdk add api --api-version=wso2.com/v1alpha1 --kind=<kind name>
-    ```
-2. Add a new Controller to the project
+   ```sh
+   >> operator-sdk add api --api-version=wso2.com/v1alpha1 --kind=<kind name>
    ```
-   operator-sdk add controller --api-version=wso2.com/v1alpha1 --kind=<kind name>
+
+1. Add a new Controller to the project
+   ```sh
+   >> operator-sdk add controller --api-version=wso2.com/v1alpha1 --kind=<kind name>
    ```
-    
-[operator_sdk_user_guide]:https://github.com/operator-framework/operator-sdk/blob/master/doc/user-guide.md
+
+[operator_sdk_user_guide]: https://github.com/operator-framework/operator-sdk/blob/v0.17.1/doc/user-guide.md

--- a/api-operator/deploy/controller-artifacts/operator.yaml
+++ b/api-operator/deploy/controller-artifacts/operator.yaml
@@ -33,8 +33,7 @@ spec:
       containers:
         - name: api-operator
           # Replace this with the built image name
-          # image: wso2/k8s-api-operator:1.2.0-alpha
-          image: renukafernando/k8s-api-operator:v1.2.0.alpha.v3
+          image: wso2/k8s-api-operator:1.2.0-alpha
           command:
           - api-operator
           imagePullPolicy: Always

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.apim</groupId>
     <artifactId>k8s-api-operator-distribution</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0-alpha</version>
     <name>API Operator For K8s Distribution</name>
 
     <build>

--- a/docs/GettingStarted/overview.md
+++ b/docs/GettingStarted/overview.md
@@ -13,7 +13,7 @@ For this, API Operator introduced four new custom resource definitions(CRDs) rel
 ### Custom resource: Security
 `Security` holds security-related information. You can see the API definition and data structure for Security` here. Security supports different security types: basic-auth, OAuth2, JWT, etc. The following YAML shows a sample payload for Security with JWT.
 
-```
+```yaml
 apiVersion: wso2.com/v1alpha1
 kind: Security
 metadata:
@@ -32,7 +32,7 @@ spec:
 ### Custom resource: RateLimiting
 `RateLimiting` holds rate-limiting related information. You can see the API definition and data structure for `RateLimiting` here. The following YAML shows sample payload.
 
-```
+```yaml
 apiVersion: wso2.com/v1alpha1
 kind: RateLimiting
 metadata:
@@ -60,7 +60,7 @@ Then APIM Operator will spin-up the corresponding Kubernetes deployment for the 
 
 In shared and private-jet mode, the backend can be running in separate PODs, but in sidecar mode, the gateway will run in the same POD adjacent to the backend service. The following YAML shows a sample payload for Target endpoint.
 
-```
+```yaml
 apiVersion: wso2.com/v1alpha1
 kind: TargetEndpoint
 metadata:
@@ -85,7 +85,7 @@ spec:
 ### Custom resource: API
 `API` holds API-related information. You can see the API definition and data structure for API  here. API takes the Swagger definition as a configMap along with replica count and micro-gateway deployment mode. The following YAML shows sample payload for API.
 
-```
+```yaml
 apiVersion: wso2.com/v1alpha1
 kind: API
 metadata:

--- a/docs/GettingStarted/quick-start-guide.md
+++ b/docs/GettingStarted/quick-start-guide.md
@@ -30,16 +30,16 @@ In this document, we will walk through on the following.
 
 - An account in DockerHub or private docker registry
 
-- Download [k8s-api-operator-1.1.0.zip](https://github.com/wso2/k8s-api-operator/releases/download/v1.1.0/k8s-api-operator-1.1.0.zip) and extract the zip
+- Download [k8s-api-operator-1.2.0-alpha.zip](https://github.com/wso2/k8s-api-operator/releases/download/v1.2.0-alpha/k8s-api-operator-1.2.0-alpha.zip) and extract the zip
 
     1. This zip contains the artifacts that required to deploy in Kubernetes.
-    2. Extract k8s-api-operator-1.1.0.zip
+    2. Extract k8s-api-operator-1.2.0-alpha.zip
     
     ```
-    cd k8s-api-operator-1.1.0
+    cd k8s-api-operator-1.2.0-alpha
     ```
  
-    **_Note:_** You need to run all commands from within the ***k8s-api-operator-1.1.0*** directory.
+    **_Note:_** You need to run all commands from within the ***k8s-api-operator-1.2.0-alpha*** directory.
 
 <br />
 

--- a/docs/GettingStarted/quick-start-guide.md
+++ b/docs/GettingStarted/quick-start-guide.md
@@ -2,7 +2,12 @@
 
 ## Introduction
 
-As microservices are increasingly being deployed on Kubernetes, the need to expose these microservices as well documented, easy to consume, managed APIs is becoming important to develop great applications. The API operator for Kubernetes makes APIs a first-class citizen in the Kubernetes ecosystem. Similar to deploying microservices, you can now use this operator to deploy APIs for individual microservices or compose several microservices into individual APIs. With this users will be able to expose their microservice as managed API in Kubernetes environment without any additional work.
+As microservices are increasingly being deployed on Kubernetes, the need to expose these microservices
+as well documented, easy to consume, managed APIs is becoming important to develop great applications.
+The API operator for Kubernetes makes APIs a first-class citizen in the Kubernetes ecosystem.
+Similar to deploying microservices, you can now use this operator to deploy APIs for individual microservices
+or compose several microservices into individual APIs. With this users will be able to expose their microservice
+as managed API in Kubernetes environment without any additional work.
 
 
 ![Alt text](../images/K8s-API-Operator.png?raw=true "K8s API Operator")
@@ -46,7 +51,8 @@ In this document, we will walk through on the following.
 #### Step 1: Deploy a sample microservice in Kubernetes
 
 
-- Let’s deploy a sample microservice in K8s which lists the details of products. This will deploy a pod and service for the sample service.
+- Let’s deploy a sample microservice in K8s which lists the details of products.
+This will deploy a pod and service for the sample service.
 
     ```sh
     >> kubectl apply -f scenarios/scenario-1/products_dep.yaml
@@ -67,7 +73,8 @@ In this document, we will walk through on the following.
     <details><summary>If you are using Minikube click here</summary>
     <p>
     
-    **_Note:_**  By default API operator requires the LoadBalancer service type which is not supported in Minikube by default. Here is how you can enable it on Minikube.
+    **_Note:_**  By default API operator requires the LoadBalancer service type which is not supported in Minikube
+    by default. Here is how you can enable it on Minikube.
     
     - On Minikube, the LoadBalancer type makes the Service accessible through the minikube service command.
     
@@ -89,7 +96,13 @@ In this document, we will walk through on the following.
     >> curl -X GET http://<EXTERNAL_IP>:80/products
          
     Output:
-    {"products":[{"name":"Apples", "id":101, "price":"$1.49 / lb"}, {"name":"Macaroni & Cheese", "id":151, "price":"$7.69"}, {"name":"ABC Smart TV", "id":301, "price":"$399.99"}, {"name":"Motor Oil", "id":401, "price":"$22.88"}, {"name":"Floral Sleeveless Blouse", "id":501, "price":"$21.50"}]}
+    {"products":[
+        {"name":"Apples", "id":101, "price":"$1.49 / lb"},
+        {"name":"Macaroni & Cheese", "id":151, "price":"$7.69"},
+        {"name":"ABC Smart TV", "id":301, "price":"$399.99"},
+        {"name":"Motor Oil", "id":401, "price":"$22.88"},
+        {"name":"Floral Sleeveless Blouse", "id":501, "price":"$21.50"}
+    ]}
     ```
    
     ```sh
@@ -204,7 +217,8 @@ API image.
     wso2apim   NodePort   10.0.39.192   <none>        8280:32004/TCP,8243:32003/TCP,9763:32002/TCP,9443:32001/TCP   114s
     ```
 
-    **_Note:_** To access the API portal, add host mapping entry to the /etc/hosts file. As we have exposed the API portal service in Node Port type, you can use the IP address of any Kubernetes node.
+    **_Note:_** To access the API portal, add host mapping entry to the /etc/hosts file.
+    As we have exposed the API portal service in Node Port type, you can use the IP address of any Kubernetes node.
     
     ```sh
     <ANY_K8S_NODE_IP>  wso2apim
@@ -224,7 +238,8 @@ API image.
 
 #### Step 5: Expose the sample microservice as a managed API
 
-Let’s deploy an API for our microservice. The Open API definition of the API can be found in the scenario/scenario-1/products-swagger.yaml.
+Let’s deploy an API for our microservice. The Open API definition of the API can be found
+in the scenario/scenario-1/products-swagger.yaml.
 
 The endpoint of our microservice is referred in the API definition.
 
@@ -248,18 +263,23 @@ The endpoint of our microservice is referred in the API definition.
     --namespace=wso2      Namespace to deploy the API
     --override            Overwrite the docker image creation for already created docker image
     
-    >> apictl add api -n <API_NAME> --from-file=<LOCATION_TO_THE_OPEN_API_DEFINITION> --replicas=<NUMBER_OF_REPLICAS> --namespace=<DESIRED_NAMESPACE>
+    >> apictl add api -n <API_NAME> --from-file=<LOCATION_TO_THE_OPEN_API_DEFINITION> \
+        --replicas=<NUMBER_OF_REPLICAS> \
+        --namespace=<DESIRED_NAMESPACE>
     ```
 
-    **_Note:_** Namespace and replicas are optional parameters. If they are not provided, the default namespace will be used and 1 replica will be created. 
+    **_Note:_** Namespace and replicas are optional parameters. If they are not provided,
+    the default namespace will be used and 1 replica will be created. 
 
-    When you deploy the API, it will first run the Kaniko job. This basically builds the docker image of the API and pushes it to Docker-Hub. 
+    When you deploy the API, it will first run the Kaniko job. \
+    This basically builds the docker image of the API and pushes it to Docker-Hub. 
 
     Once the Kaniko job is completed, it will deploy the managed API for your microservice.
 
 - Verify the API deployment
 
-    If you list down the pods immediately after the add API command you will only see the pod related to Kaniko job. Once it is completed you will see the deployed API. If you are on Minikube, this might take several minutes.
+    If you list down the pods immediately after the add API command you will only see the pod related to Kaniko job.
+    Once it is completed you will see the deployed API. If you are on Minikube, this might take several minutes.
 
     ```sh
     >> apictl get pods 
@@ -296,7 +316,8 @@ The endpoint of our microservice is referred in the API definition.
 
 - Retrieve the API service endpoint details
 
-    The API service is exposed as the Load Balancer service type. You can get the API service endpoint details by using the following command.
+    The API service is exposed as the Load Balancer service type.
+    You can get the API service endpoint details by using the following command.
 
     ```sh
     >> apictl get services
@@ -309,7 +330,8 @@ The endpoint of our microservice is referred in the API definition.
     <details><summary>If you are using Minikube click here</summary>
     <p>
     
-    **_Note:_**  By default API operator requires the LoadBalancer service type which is not supported in Minikube by default. Here is how you can enable it on Minikube.
+    **_Note:_**  By default API operator requires the LoadBalancer service type which is not supported
+    in Minikube by default. Here is how you can enable it on Minikube.
     
     - On Minikube, the LoadBalancer type makes the Service accessible through the minikube service command.
     
@@ -335,7 +357,13 @@ The endpoint of our microservice is referred in the API definition.
     You will get an error as below.
     
     ```json
-    {"fault":{"code":900902, "message":"Missing Credentials", "description":"Missing Credentials. Make sure your API invocation call has a header: \"Authorization\""}}
+    {
+        "fault": {
+            "code": 900902,
+            "message": "Missing Credentials",
+            "description": "Missing Credentials. Make sure your API invocation call has a header: \"Authorization\""
+        }
+    }
     ```
     
     Since the API is secured now, you are experiencing the above error. Hence you need a valid access token to invoke the API.
@@ -363,7 +391,8 @@ The endpoint of our microservice is referred in the API definition.
     >> curl -X GET "https://35.232.188.134:9095/store/v1.0.0/products/101" -H "Authorization:Bearer $TOKEN" -k
     ```
     
-    **_Note:_** In a production-level scenario, there should be a way to discover the available services and obtain an access token in a secured manner. For this, we need to push this API to API Portal and get an OAuth 2.0 access token
+    **_Note:_** In a production-level scenario, there should be a way to discover the available services and obtain
+    an access token in a secured manner. For this, we need to push this API to API Portal and get an OAuth 2.0 access token
 
 
 <br />
@@ -371,13 +400,15 @@ The endpoint of our microservice is referred in the API definition.
 #### Step 7: Pushing the API to the API Portal
 
 
-To make the API discoverable for other users and get the access tokens, we need to push the API to the API portal. Then the app developers/subscribers can navigate to the devportal (https://wso2apim:32001/devportal) to perform the following actions.
+To make the API discoverable for other users and get the access tokens, we need to push the API to the API portal.
+Then the app developers/subscribers can navigate to the devportal (https://wso2apim:32001/devportal) to perform the following actions.
 
 - Create an application
 - Subscribe the API to the application
 - Generate a JWT access token 
 
-The following commands will help you to push the API to the API portal in Kubernetes. Commands of the API Controller can be found [here](https://github.com/wso2/product-apim-tooling/blob/v3.0.0-rc/import-export-cli/docs/apictl.md) 
+The following commands will help you to push the API to the API portal in Kubernetes.
+Commands of the API Controller can be found [here](https://github.com/wso2/product-apim-tooling/blob/v3.0.0-rc/import-export-cli/docs/apictl.md) 
 
 
 - Add the API portal as an environment to the API controller using the following command.
@@ -415,7 +446,8 @@ The following commands will help you to push the API to the API portal in Kubern
 
 #### Step 8: Generate an access token for the API
 
-- By default the API is secured with JWT. Hence a valid JWT token is needed to invoke the API. You can obtain a JWT token using the API Controller command as below.
+- By default the API is secured with JWT. Hence a valid JWT token is needed to invoke the API.
+You can obtain a JWT token using the API Controller command as below.
     
     ```sh
     >> apictl set --token-type JWT
@@ -445,7 +477,8 @@ You can find the documentation [here](../Readme.md).
 
 ### Cleanup
 
-- Execute the following commands if you wish to clean up the Kubernetes cluster by removing all the applied artifacts and configurations related to API operator and API portal.
+- Execute the following commands if you wish to clean up the Kubernetes cluster by removing all the applied artifacts
+and configurations related to API operator and API portal.
 
     ```sh
     >> apictl delete api online-store

--- a/docs/GettingStarted/quick-start-guide.md
+++ b/docs/GettingStarted/quick-start-guide.md
@@ -119,11 +119,13 @@ In this document, we will walk through on the following.
 
 #### Step 3: Install API Operator
 
-- Execute the following command to install API Operator interactively and configure repository to push the microgateway image.
+- Execute the following command to install API Operator interactively and configure repository to push the built managed
+API image.
 - Select "Docker Hub" as the repository type.
 - Enter repository name of your Docker Hub account (usually it is the username as well).
-- Enter username and the password
-- Confirm configuration are correct with entering "Y"
+  - Supports both `jennifer` and `docker.io/jennifer` (backward compatibility) as repository name.
+- Enter username and the password.
+- Confirm configuration are correct with entering "Y".
 
     ```sh
     >> apictl install api-operator
@@ -135,11 +137,11 @@ In this document, we will walk through on the following.
     5: HTTPS Private Registry
     6: Quay.io
     Choose a number: 1: 1
-    Enter repository name: docker.io/jennifer
+    Enter repository name: jennifer
     Enter username: jennifer
     Enter password: *******
     
-    Repository: docker.io/jennifer
+    Repository: jennifer
     Username  : jennifer
     Confirm configurations: Y: Y
     

--- a/docs/GettingStarted/quick-start-guide.md
+++ b/docs/GettingStarted/quick-start-guide.md
@@ -35,7 +35,7 @@ In this document, we will walk through on the following.
     1. This zip contains the artifacts that required to deploy in Kubernetes.
     2. Extract k8s-api-operator-1.2.0-alpha.zip
     
-    ```
+    ```sh
     cd k8s-api-operator-1.2.0-alpha
     ```
  
@@ -48,7 +48,7 @@ In this document, we will walk through on the following.
 
 - Let’s deploy a sample microservice in K8s which lists the details of products. This will deploy a pod and service for the sample service.
 
-    ```
+    ```sh
     >> kubectl apply -f scenarios/scenario-1/products_dep.yaml
     service/products created
     deployment.apps/products-deployment created
@@ -56,7 +56,7 @@ In this document, we will walk through on the following.
 
     The following command will give you the details of the microservice.
 
-    ```
+    ```sh
     >> kubectl get services products
   
     Output:
@@ -71,7 +71,7 @@ In this document, we will walk through on the following.
     
     - On Minikube, the LoadBalancer type makes the Service accessible through the minikube service command.
     
-        ```
+        ```sh
         >> minikube service <SERVICE_NAME> --url
         >> minikube service products --url
         ```
@@ -85,15 +85,15 @@ In this document, we will walk through on the following.
 <br>
 
 - To test the microservice, execute the following commands.
-    ```
-    >> curl -X GET http://<EXTERNAL-IP>:80/products
+    ```sh
+    >> curl -X GET http://<EXTERNAL_IP>:80/products
          
     Output:
     {"products":[{"name":"Apples", "id":101, "price":"$1.49 / lb"}, {"name":"Macaroni & Cheese", "id":151, "price":"$7.69"}, {"name":"ABC Smart TV", "id":301, "price":"$399.99"}, {"name":"Motor Oil", "id":401, "price":"$22.88"}, {"name":"Floral Sleeveless Blouse", "id":501, "price":"$21.50"}]}
     ```
    
-    ```
-    >> curl -X GET http://<EXTERNAL-IP>:80/products/101
+    ```sh
+    >> curl -X GET http://<EXTERNAL_IP>:80/products/101
          
     Output:
     {"name":"Apples", "id":101, "price":"$1.49 / lb", "reviewScore":"0", "stockAvailability":false}
@@ -112,7 +112,7 @@ In this document, we will walk through on the following.
 
 - You can find available operations using the below command.
     
-  ```
+  ```sh
   >> apictl --help
   ```
 <br />
@@ -128,22 +128,23 @@ In this document, we will walk through on the following.
     ```sh
     >> apictl install api-operator
     Choose registry type:
-    1: Docker Hub (Or others, quay.io, HTTPS registry)
+    1: Docker Hub
     2: Amazon ECR
     3: GCR
     4: HTTP Private Registry
+    5: HTTPS Private Registry
+    6: Quay.io
     Choose a number: 1: 1
-    Enter repository name (docker.io/john | quay.io/mark | 10.100.5.225:5000/jennifer): docker.io/jennifer
+    Enter repository name: docker.io/jennifer
     Enter username: jennifer
     Enter password: *******
     
     Repository: docker.io/jennifer
     Username  : jennifer
     Confirm configurations: Y: Y
-    ```
     
+  
     Output:
-    ```sh
     customresourcedefinition.apiextensions.k8s.io/apis.wso2.com created
     customresourcedefinition.apiextensions.k8s.io/ratelimitings.wso2.com created
     ...
@@ -163,7 +164,7 @@ In this document, we will walk through on the following.
 
 - Install the WSO2AM Operator in Kubernetes.
 
-    ```
+    ```sh
     >> apictl install wso2am-operator
     
     namespace/wso2-system created
@@ -176,7 +177,7 @@ In this document, we will walk through on the following.
 
 - Install API Portal and security token service under a namespace called "wso2"
 
-    ```
+    ```sh
     >> apictl apply -f k8s-artifacts/wso2am-operator/api-portal/
     
     Output:
@@ -187,7 +188,7 @@ In this document, we will walk through on the following.
 
 - Access API Portal and security token service
 
-    ```
+    ```sh
     >> apictl get pods -n wso2
     
     Output:
@@ -203,8 +204,8 @@ In this document, we will walk through on the following.
 
     **_Note:_** To access the API portal, add host mapping entry to the /etc/hosts file. As we have exposed the API portal service in Node Port type, you can use the IP address of any Kubernetes node.
     
-    ```
-    <Any K8s Node IP>  wso2apim
+    ```sh
+    <ANY_K8S_NODE_IP>  wso2apim
     ```
     
     - For Docker for Mac use "127.0.0.1" for the K8s node IP
@@ -227,7 +228,7 @@ The endpoint of our microservice is referred in the API definition.
 
 - Deploy the API using the following command
 
-    ```
+    ```sh
     >> apictl add api -n <API_NAME> --from-file=<LOCATION_TO_THE_OPEN_API_DEFINITION>
     
     >> apictl add api -n online-store --from-file=scenarios/scenario-1/products_swagger.yaml
@@ -240,7 +241,7 @@ The endpoint of our microservice is referred in the API definition.
 
     Optional Parameters
     
-    ```
+    ```sh
     --replicas=3          Number of replicas
     --namespace=wso2      Namespace to deploy the API
     --override            Overwrite the docker image creation for already created docker image
@@ -258,7 +259,7 @@ The endpoint of our microservice is referred in the API definition.
 
     If you list down the pods immediately after the add API command you will only see the pod related to Kaniko job. Once it is completed you will see the deployed API. If you are on Minikube, this might take several minutes.
 
-    ```
+    ```sh
     >> apictl get pods 
     
     Output:
@@ -268,7 +269,7 @@ The endpoint of our microservice is referred in the API definition.
 
     If you execute the same command after sometime you will see the managed API has been deployed after the Kaniko job.
 
-    ```
+    ```sh
     >> apictl get pods 
     
     Output:
@@ -276,7 +277,7 @@ The endpoint of our microservice is referred in the API definition.
     online-store-6957fc89d6-kn9sp          1/1     Running   0          21s
     ```
 
-    ```
+    ```sh
     >> apictl get services 
     
     Output:
@@ -295,7 +296,7 @@ The endpoint of our microservice is referred in the API definition.
 
     The API service is exposed as the Load Balancer service type. You can get the API service endpoint details by using the following command.
 
-    ```
+    ```sh
     >> apictl get services
     
     Output:
@@ -310,7 +311,7 @@ The endpoint of our microservice is referred in the API definition.
     
     - On Minikube, the LoadBalancer type makes the Service accessible through the minikube service command.
     
-        ```
+        ```sh
         >> minikube service <SERVICE_NAME> --url
         >> minikube service online-store --url
         ```
@@ -325,13 +326,13 @@ The endpoint of our microservice is referred in the API definition.
 - Invoke the API as a regular microservice
 
     Let’s observe what happens if you try to invoke the API as a regular microservice.
-    ```
+    ```sh
     >> curl -X GET "https://<EXTERNAL-IP>:9095/store/v1.0.0/products" -k
     ```
     
     You will get an error as below.
     
-    ```
+    ```json
     {"fault":{"code":900902, "message":"Missing Credentials", "description":"Missing Credentials. Make sure your API invocation call has a header: \"Authorization\""}}
     ```
     
@@ -341,12 +342,12 @@ The endpoint of our microservice is referred in the API definition.
 
     You can find a sample token below.
     
-    ```
+    ```sh
    TOKEN=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik5UZG1aak00WkRrM05qWTBZemM1TW1abU9EZ3dNVEUzTVdZd05ERTVNV1JsWkRnNE56YzRaQT09In0.eyJhdWQiOiJodHRwOlwvXC9vcmcud3NvMi5hcGltZ3RcL2dhdGV3YXkiLCJzdWIiOiJhZG1pbkBjYXJib24uc3VwZXIiLCJhcHBsaWNhdGlvbiI6eyJvd25lciI6ImFkbWluIiwidGllciI6IjEwUGVyTWluIiwibmFtZSI6InNhbXBsZS1jcmQtYXBwbGljYXRpb24iLCJpZCI6NCwidXVpZCI6bnVsbH0sInNjb3BlIjoiYW1fYXBwbGljYXRpb25fc2NvcGUgZGVmYXVsdCIsImlzcyI6Imh0dHBzOlwvXC93c28yYXBpbTozMjAwMVwvb2F1dGgyXC90b2tlbiIsInRpZXJJbmZvIjp7fSwia2V5dHlwZSI6IlBST0RVQ1RJT04iLCJzdWJzY3JpYmVkQVBJcyI6W10sImNvbnN1bWVyS2V5IjoieF8xal83MW11dXZCb01SRjFLZnVLdThNOVVRYSIsImV4cCI6MzczMTQ5Mjg2MSwiaWF0IjoxNTg0MDA5MjE0LCJqdGkiOiJkYTA5Mjg2Yy03OGEzLTQ4YjgtYmFiNy1hYWZiYzhiMTUxNTQifQ.MKmGDwh855NrZ2wOvXO7TwFbCtsgsOFuoZW4DBVIbJ1KQ2F6TgTgBbtzBUvrYGPslEExMemhepfvvlYv8Gd6MMo3GVH4aO8AKyc8gHmeIQ8MQtXGn7u9N00ZW3_9JWaQkU-OYEDsLHvKKHzO0t2umaskSyCS2UkAS4wIT_szZ5sm-O-ez4nKGeJmESiV-1EchFjOhLpEH4p9wIj3MlKnZrIcJByRKK9ZGaHBqxwwYuJtMCDNa2wFAPMOh-45eabIUdo1KUO3gZLVcME93aza1t1jzL9mFsx0LGaXIxB7klrDuBCAdG9Yi3O7-3WUF74QaS2tmCxW36JhhOJ5DdacfQ
     ```
     Copy and paste the above token in the command line. Now you can invoke the API using the cURL command as below.
     
-    ```
+    ```sh
     Format: 
     
     >> curl -X GET "https://<EXTERNAL-IP>:9095/<API-context>/<API-resource>"  -H "Authorization:Bearer $TOKEN" -k
@@ -354,7 +355,7 @@ The endpoint of our microservice is referred in the API definition.
 
     Example commands:
     
-    ```
+    ```sh
     >> curl -X GET "https://35.232.188.134:9095/store/v1.0.0/products" -H "Authorization:Bearer $TOKEN" -k
     
     >> curl -X GET "https://35.232.188.134:9095/store/v1.0.0/products/101" -H "Authorization:Bearer $TOKEN" -k
@@ -379,7 +380,7 @@ The following commands will help you to push the API to the API portal in Kubern
 
 - Add the API portal as an environment to the API controller using the following command.
 
-    ```
+    ```sh
     >> apictl add-env -e k8s --apim https://wso2apim:32001 --token https://wso2apim:32001/oauth2/token
     
     Output:
@@ -388,7 +389,7 @@ The following commands will help you to push the API to the API portal in Kubern
 
 - Initialize the API project using API Controller
 
-    ```
+    ```sh
     >> apictl init online-store --oas=./scenarios/scenario-1/products_swagger.yaml --initial-state=PUBLISHED
     
     Output:
@@ -402,7 +403,7 @@ The following commands will help you to push the API to the API portal in Kubern
     For testing purpose use ***admin*** as username and password when prompted.
     </br>
     
-    ```
+    ```sh
     >> apictl import-api -f online-store/ -e k8s -k
     
     Output:
@@ -414,7 +415,7 @@ The following commands will help you to push the API to the API portal in Kubern
 
 - By default the API is secured with JWT. Hence a valid JWT token is needed to invoke the API. You can obtain a JWT token using the API Controller command as below.
     
-    ``` 
+    ```sh
     >> apictl set --token-type JWT
     
     Output: 
@@ -422,7 +423,7 @@ The following commands will help you to push the API to the API portal in Kubern
     ```
 - Generate access token for the API with the following command.
 
-    ```
+    ```sh
     >> apictl get-keys -n online-store -v v1.0.0 -e k8s --provider admin -k
     
     Output:
@@ -444,7 +445,7 @@ You can find the documentation [here](../Readme.md).
 
 - Execute the following commands if you wish to clean up the Kubernetes cluster by removing all the applied artifacts and configurations related to API operator and API portal.
 
-    ```
+    ```sh
     >> apictl delete api online-store
     >> apictl delete -f k8s-artifacts/api-portal
     >> apictl remove-env -e k8s

--- a/docs/HowToGuide/OverviewOfCrds/apply-rate-limiting-to-api.md
+++ b/docs/HowToGuide/OverviewOfCrds/apply-rate-limiting-to-api.md
@@ -21,7 +21,7 @@ Example: In the following ratelimiting policies the namespace is provided as "ws
 referred should be "wso2-test-ns". 
 
 * Application throttling
-```
+```yaml
 apiVersion: wso2.com/v1alpha1
 kind: RateLimiting
 metadata:
@@ -37,7 +37,7 @@ spec:
 ```
 
 * Subscription throttling
-```
+```yaml
 apiVersion: wso2.com/v1alpha1
 kind: RateLimiting
 metadata:
@@ -52,7 +52,7 @@ spec:
    limit: 6
 ```
 * Advance throttling 
-```
+```yaml
 apiVersion: wso2.com/v1alpha1
 kind: RateLimiting
 metadata:

--- a/docs/HowToGuide/OverviewOfCrds/perform-api-operations.md
+++ b/docs/HowToGuide/OverviewOfCrds/perform-api-operations.md
@@ -13,7 +13,7 @@ Format:
 ```
 ***NOTE:*** Here ***API_PROJECT*** refers to a project initialized using `apictl init command`
 
-```
+```sh
 >> apictl add api -n online-store --from-file=scenarios/scenario-1/products_swagger.yaml
 
 Output:

--- a/docs/HowToGuide/WorkingWithDockerRegistries/working-with-aws.md
+++ b/docs/HowToGuide/WorkingWithDockerRegistries/working-with-aws.md
@@ -49,10 +49,12 @@ You can use Amazon ECR as the registry or other registry type. Following [Instal
 ```sh
 >> apictl install api-operator
 Choose repository type:
-1: Docker Hub (Or others, quay.io, HTTPS registry)
+1: Docker Hub
 2: Amazon ECR
 3: GCR
 4: HTTP Private Registry
+5: HTTPS Private Registry
+6: Quay.io
 Choose a number: 1: 2
 Enter repository name (<aws_account_id.dkr.ecr.region.amazonaws.com>/repository): 610968236798.dkr.ecr.us-east-2.amazonaws.com/my-ecr-repo
 Amazon credential file: /Users/wso2/.aws/credentials:

--- a/docs/HowToGuide/WorkingWithDockerRegistries/working-with-gcr.md
+++ b/docs/HowToGuide/WorkingWithDockerRegistries/working-with-gcr.md
@@ -16,10 +16,12 @@ Follow the [cloud.google.com documentation](https://cloud.google.com/docs/authen
 ```sh
 >> apictl install api-operator
 Choose registry type:
-1: Docker Hub (Or others, quay.io, HTTPS registry)
+1: Docker Hub
 2: Amazon ECR
 3: GCR
 4: HTTP Private Registry
+5: HTTPS Private Registry
+6: Quay.io
 Choose a number: 1: 3
 GCR service account key json file: /path/to/gcr/service/account/key/file.json
 

--- a/docs/HowToGuide/WorkingWithDockerRegistries/working-with-http-https-repository.md
+++ b/docs/HowToGuide/WorkingWithDockerRegistries/working-with-http-https-repository.md
@@ -101,10 +101,12 @@ Follow the documentation https://docs.docker.com/registry/deploying for more inf
 ```sh
 >> apictl install api-operator
 Choose registry type:
-1: Docker Hub (Or others, quay.io, HTTPS registry)
+1: Docker Hub
 2: Amazon ECR
 3: GCR
 4: HTTP Private Registry
+5: HTTPS Private Registry
+6: Quay.io
 Choose a number: 1: 4
 Enter private registry (10.100.5.225:5000/jennifer): myregistrydomain.com:5001/my-repository
 Enter username: TEST_USER
@@ -134,12 +136,14 @@ namespace/wso2-system created
 ```sh
 >> apictl install api-operator
 Choose registry type:
-1: Docker Hub (Or others, quay.io, HTTPS registry)
+1: Docker Hub
 2: Amazon ECR
 3: GCR
 4: HTTP Private Registry
-Choose a number: 1: 1
-Enter repository name (docker.io/john | quay.io/mark | 10.100.5.225:5000/jennifer): myregistrydomain.com:5002/my-repository
+5: HTTPS Private Registry
+6: Quay.io
+Choose a number: 1: 5
+Enter repository name: myregistrydomain.com:5002/my-repository
 Enter username: TEST_USER
 Enter password:
 

--- a/docs/HowToGuide/install-api-operator-in-cicd.md
+++ b/docs/HowToGuide/install-api-operator-in-cicd.md
@@ -15,7 +15,7 @@ Flags:
 
 For offline installation use the `--from-file` flag to point the operator configs downloaded from the [release](https://github.com/wso2/k8s-api-operator/releases). The flag `--from-file` can be used with any registry type.
 
-## 1. Docker Hub or HTTPS registry
+## 1. Docker Hub
 
 ```sh
 Format:
@@ -26,12 +26,6 @@ Format:
 ```sh
 Docker-Hub:
 >> apictl install api-operator --registry-type=DOCKER_HUB --repository=docker.io/wso2 --username=john --password=*******
-
-Quay.io:
->> apictl install api-operator --registry-type=DOCKER_HUB --repository=quay.io/wso2 --username=mark --password=*******
-
-HTTPS registry:
->> apictl install api-operator --registry-type=DOCKER_HUB --repository=10.100.5.225:5000/wso2 --username=jennifer --password=*******
 ```
 
 ## 2. Amazon ECR
@@ -64,3 +58,22 @@ Example:
 >> apictl install api-operator --registry-type=HTTP --repository=10.100.5.225:5000/wso2 --username=jennifer --password=********
 ```
 
+## 5. HTTPS private registry
+
+```sh
+Format:
+>> apictl install api-operator --registry-type=HTTPS --repository=<REPOSITORY> --username=<USER_NAME> --password=<PASSWORD>
+
+Example:
+>> apictl install api-operator --registry-type=HTTPS --repository=10.100.5.225:5000/wso2 --username=jennifer --password=********
+```
+
+## 6. HTTPS private registry
+
+```sh
+Format:
+>> apictl install api-operator --registry-type=QUAY --repository=<REPOSITORY> --username=<USER_NAME> --password=<PASSWORD>
+
+Example:
+>> apictl install api-operator --registry-type=QUAY --repository=john --username=john --password=********
+```

--- a/docs/HowToGuide/working-with-kaniko-additional-flags.md
+++ b/docs/HowToGuide/working-with-kaniko-additional-flags.md
@@ -17,7 +17,7 @@ If you wish to add these additional flags to the Kaniko job, please follow the i
 2. Include the [Kaniko additional flags]((https://github.com/GoogleContainerTools/kaniko#additional-flags)) you need under ***KanikoArguments***. 
 
 An example is shown below.
-```
+```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/k8s-artifacts/api-portal-with-analytics/api-analytics/analytics-dashboard-deployment.yaml
+++ b/k8s-artifacts/api-portal-with-analytics/api-analytics/analytics-dashboard-deployment.yaml
@@ -39,7 +39,7 @@ spec:
           command: ["sh", "-c", "for i in $(seq 1 300); do nc -zvw1 wso2apim-with-analytics-rdbms-service 3306 && exit 0 || sleep 3; done; exit 1"]
       containers:
         - name: wso2apim-dashboard-analytics
-          image: wso2/wso2am-analytics-dashboard:3.1.0
+          image: pubudu/wso2am-analytics-dashboard:3.2.0-beta
           resources:
             limits:
               memory: "2Gi"

--- a/k8s-artifacts/api-portal-with-analytics/api-analytics/analytics-worker-deployment.yaml
+++ b/k8s-artifacts/api-portal-with-analytics/api-analytics/analytics-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
           command: ["sh", "-c", "for i in $(seq 1 300); do nc -zvw1 wso2apim-with-analytics-rdbms-service 3306 && exit 0 || sleep 3; done; exit 1"]
       containers:
         - name: wso2apim-analytics
-          image: wso2/wso2am-analytics-worker:3.1.0
+          image: pubudu/wso2am-analytics-worker:3.2.0-beta
           resources:
             limits:
               memory: "2Gi"

--- a/k8s-artifacts/api-portal-with-analytics/api-portal/wso2apim-deployment.yaml
+++ b/k8s-artifacts/api-portal-with-analytics/api-portal/wso2apim-deployment.yaml
@@ -45,7 +45,7 @@ spec:
           command: ["sh", "-c", "for i in $(seq 1 300); do nc -zvw1 wso2apim-dashboard-analytics-service 9643 && exit 0 || sleep 3; done; exit 1"]
       containers:
         - name: wso2apim
-          image: pubudu/wso2am:3.2.0-alpha
+          image: pubudu/wso2am:3.2.0-beta
           resources:
             limits:
               memory: "2Gi"

--- a/k8s-artifacts/api-portal/wso2apim-deployment.yaml
+++ b/k8s-artifacts/api-portal/wso2apim-deployment.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
         - name: wso2apim
-          image: pubudu/wso2am:3.2.0-alpha
+          image: pubudu/wso2am:3.2.0-beta
           resources:
             limits:
               memory: "2Gi"

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.apim</groupId>
     <artifactId>k8s-api-operator</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0-alpha</version>
     <name>API Operator For K8S</name>
     <packaging>pom</packaging>
 

--- a/scenarios/scenario-1/README.md
+++ b/scenarios/scenario-1/README.md
@@ -37,7 +37,7 @@ kubernetes cluster as a managed API in the Kubernetes cluster.
  - To test if the product service is working, execute the following commands.
     ```
     Command 1:
-    curl -X GET http://<EXTERNAL-IP>:80/products
+    >> curl -X GET http://<EXTERNAL_IP>:80/products
     
     Output:
     {"products":[{"name":"Apples", "id":101, "price":"$1.49 / lb"}, {"name":"Macaroni & Cheese", "id":151, "price":"$7.69"}, {"name":"ABC Smart TV", "id":301, "price":"$399.99"}, {"name":"Motor Oil", "id":401, "price":"$22.88"}, {"name":"Floral Sleeveless Blouse", "id":501, "price":"$21.50"}]}
@@ -45,7 +45,7 @@ kubernetes cluster as a managed API in the Kubernetes cluster.
     
     ```
     Command 2:
-    curl -X GET http://104.197.114.248:80/products/101
+    >> curl -X GET http://<EXTERNAL_IP>:80/products/101
     
     Output:
     {"name":"Apples", "id":101, "price":"$1.49 / lb", "reviewScore":"0", "stockAvailability":false}

--- a/scenarios/scenario-11/README.md
+++ b/scenarios/scenario-11/README.md
@@ -80,8 +80,8 @@ To try out the scenario navigate to ```k8s-api-operator-<version>``` directory.
     **Note:** To access the API portal and Analytics dashboard, add host mapping entries to the /etc/hosts file. As we have exposed the services in Node Port type, you can use the IP address of any Kubernetes node.
     
     ```
-    <Any K8s Node IP>  wso2apim
-    <Any K8s Node IP>  wso2apim-analytics
+    <ANY_K8S_NODE_IP>  wso2apim
+    <ANY_K8S_NODE_IP>  wso2apim-analytics
     ```
 
     - For Docker for Mac use "127.0.0.1" for the K8s node IP

--- a/scenarios/scenario-13/S01-APIM_for_Istio_Services/README.md
+++ b/scenarios/scenario-13/S01-APIM_for_Istio_Services/README.md
@@ -60,12 +60,14 @@ This works only in Istio permissive mode.
     ```
     >> apictl install api-operator
     Choose registry type:
-    1: Docker Hub (Or others, quay.io, HTTPS registry)
+    1: Docker Hub
     2: Amazon ECR
     3: GCR
     4: HTTP Private Registry
+    5: HTTPS Private Registry
+    6: Quay.io
     Choose a number: 1: 1
-    Enter repository name (docker.io/john | quay.io/mark | 10.100.5.225:5000/jennifer): docker.io/jennifer
+    Enter repository name: docker.io/jennifer
     Enter username: jennifer
     Enter password: *******
     

--- a/scenarios/scenario-13/S01-APIM_for_Istio_Services/README.md
+++ b/scenarios/scenario-13/S01-APIM_for_Istio_Services/README.md
@@ -170,8 +170,14 @@ This works only in Istio permissive mode.
      
      You will get an error as below.
      
-     ```
-     {"fault":{"code":900902, "message":"Missing Credentials", "description":"Missing Credentials. Make sure your API invocation call has a header: \"Authorization\""}}
+     ```json
+     {
+         "fault": {
+             "code": 900902,
+             "message": "Missing Credentials",
+             "description": "Missing Credentials. Make sure your API invocation call has a header: \"Authorization\""
+         }
+     }
      ```
      
      Since the API is secured now, you are experiencing the above error. Hence you need a valid access token to invoke the API.

--- a/scenarios/scenario-13/S01-APIM_for_Istio_Services/README.md
+++ b/scenarios/scenario-13/S01-APIM_for_Istio_Services/README.md
@@ -19,13 +19,13 @@ This works only in Istio permissive mode.
 
 - An account in DockerHub or private docker registry
 
-- Download [k8s-api-operator-1.1.0.zip](https://github.com/wso2/k8s-api-operator/releases/download/v1.1.0/k8s-api-operator-1.1.0.zip) and extract the zip
+- Download [k8s-api-operator-1.2.0-alpha.zip](https://github.com/wso2/k8s-api-operator/releases/download/v1.2.0-alpha/k8s-api-operator-1.2.0-alpha.zip) and extract the zip
 
     1. This zip contains the artifacts that required to deploy in Kubernetes.
-    2. Extract k8s-api-operator-1.1.0.zip
+    2. Extract k8s-api-operator-1.2.0-alpha.zip
     
     ```
-    cd k8s-api-operator-1.1.0/scenarios/scenario-13/S01-APIM_for_Istio_Services/
+    cd k8s-api-operator-1.2.0-alpha/scenarios/scenario-13/S01-APIM_for_Istio_Services/
     ```
  
     **_Note:_** You need to run all commands from within the ```S01-APIM_for_Istio_Services``` directory.

--- a/scenarios/scenario-13/S01-APIM_for_Istio_Services/README.md
+++ b/scenarios/scenario-13/S01-APIM_for_Istio_Services/README.md
@@ -67,11 +67,11 @@ This works only in Istio permissive mode.
     5: HTTPS Private Registry
     6: Quay.io
     Choose a number: 1: 1
-    Enter repository name: docker.io/jennifer
+    Enter repository name: jennifer
     Enter username: jennifer
     Enter password: *******
     
-    Repository: docker.io/jennifer
+    Repository: jennifer
     Username  : jennifer
     Confirm configurations: Y: Y
     ```

--- a/scenarios/scenario-13/S02-APIM_for_Istio_Services_MTLS/README.md
+++ b/scenarios/scenario-13/S02-APIM_for_Istio_Services_MTLS/README.md
@@ -67,11 +67,11 @@ This works in Istio permissive mode and Strict MTLS mode.
     5: HTTPS Private Registry
     6: Quay.io
     Choose a number: 1: 1
-    Enter repository name: docker.io/jennifer
+    Enter repository name: jennifer
     Enter username: jennifer
     Enter password: *******
     
-    Repository: docker.io/jennifer
+    Repository: jennifer
     Username  : jennifer
     Confirm configurations: Y: Y
     ```

--- a/scenarios/scenario-13/S02-APIM_for_Istio_Services_MTLS/README.md
+++ b/scenarios/scenario-13/S02-APIM_for_Istio_Services_MTLS/README.md
@@ -19,13 +19,13 @@ This works in Istio permissive mode and Strict MTLS mode.
 
 - An account in DockerHub or private docker registry
 
-- Download [k8s-api-operator-1.1.0.zip](https://github.com/wso2/k8s-api-operator/releases/download/v1.1.0/k8s-api-operator-1.1.0.zip) and extract the zip
+- Download [k8s-api-operator-1.2.0-alpha.zip](https://github.com/wso2/k8s-api-operator/releases/download/v1.2.0-alpha/k8s-api-operator-1.2.0-alpha.zip) and extract the zip
 
     1. This zip contains the artifacts that required to deploy in Kubernetes.
-    2. Extract k8s-api-operator-1.1.0.zip
+    2. Extract k8s-api-operator-1.2.0-alpha.zip
     
     ```
-    cd k8s-api-operator-1.1.0/scenarios/scenario-13/S02-APIM_for_Istio_Services_MTLS
+    cd k8s-api-operator-1.2.0-alpha/scenarios/scenario-13/S02-APIM_for_Istio_Services_MTLS
     ```
  
     **_Note:_** You need to run all commands from within the ```S02-APIM_for_Istio_Services_MTLS``` directory.

--- a/scenarios/scenario-13/S02-APIM_for_Istio_Services_MTLS/README.md
+++ b/scenarios/scenario-13/S02-APIM_for_Istio_Services_MTLS/README.md
@@ -60,12 +60,14 @@ This works in Istio permissive mode and Strict MTLS mode.
     ```
     >> apictl install api-operator
     Choose registry type:
-    1: Docker Hub (Or others, quay.io, HTTPS registry)
+    1: Docker Hub
     2: Amazon ECR
     3: GCR
     4: HTTP Private Registry
+    5: HTTPS Private Registry
+    6: Quay.io
     Choose a number: 1: 1
-    Enter repository name (docker.io/john | quay.io/mark | 10.100.5.225:5000/jennifer): docker.io/jennifer
+    Enter repository name: docker.io/jennifer
     Enter username: jennifer
     Enter password: *******
     

--- a/scenarios/scenario-13/S02-APIM_for_Istio_Services_MTLS/README.md
+++ b/scenarios/scenario-13/S02-APIM_for_Istio_Services_MTLS/README.md
@@ -175,8 +175,14 @@ This works in Istio permissive mode and Strict MTLS mode.
      
      You will get an error as below.
      
-     ```
-     {"fault":{"code":900902, "message":"Missing Credentials", "description":"Missing Credentials. Make sure your API invocation call has a header: \"Authorization\""}}
+     ```json
+     {
+         "fault": {
+             "code": 900902,
+             "message": "Missing Credentials",
+             "description": "Missing Credentials. Make sure your API invocation call has a header: \"Authorization\""
+         }
+     }
      ```
      
      Since the API is secured now, you are experiencing the above error. Hence you need a valid access token to invoke the API.

--- a/scenarios/scenario-13/S03-API_Gateway_In_Istio_As_A_Service/README.md
+++ b/scenarios/scenario-13/S03-API_Gateway_In_Istio_As_A_Service/README.md
@@ -19,13 +19,13 @@ This works in Istio permissive mode and Strict MTLS mode.
 
 - An account in DockerHub or private docker registry
 
-- Download [k8s-api-operator-1.1.0.zip](https://github.com/wso2/k8s-api-operator/releases/download/v1.1.0/k8s-api-operator-1.1.0.zip) and extract the zip
+- Download [k8s-api-operator-1.2.0-alpha.zip](https://github.com/wso2/k8s-api-operator/releases/download/v1.2.0-alpha/k8s-api-operator-1.2.0-alpha.zip) and extract the zip
 
     1. This zip contains the artifacts that required to deploy in Kubernetes.
-    2. Extract k8s-api-operator-1.1.0.zip
+    2. Extract k8s-api-operator-1.2.0-alpha.zip
     
     ```
-    cd k8s-api-operator-1.1.0/scenarios/scenario-13/S03-API_Gateway_In_Istio_As_A_Service
+    cd k8s-api-operator-1.2.0-alpha/scenarios/scenario-13/S03-API_Gateway_In_Istio_As_A_Service
     ```
  
     **_Note:_** You need to run all commands from within the ```S03-API_Gateway_In_Istio_As_A_Service``` directory.

--- a/scenarios/scenario-13/S03-API_Gateway_In_Istio_As_A_Service/README.md
+++ b/scenarios/scenario-13/S03-API_Gateway_In_Istio_As_A_Service/README.md
@@ -67,11 +67,11 @@ This works in Istio permissive mode and Strict MTLS mode.
     5: HTTPS Private Registry
     6: Quay.io
     Choose a number: 1: 1
-    Enter repository name: docker.io/jennifer
+    Enter repository name: jennifer
     Enter username: jennifer
     Enter password: *******
     
-    Repository: docker.io/jennifer
+    Repository: jennifer
     Username  : jennifer
     Confirm configurations: Y: Y
     ```

--- a/scenarios/scenario-13/S03-API_Gateway_In_Istio_As_A_Service/README.md
+++ b/scenarios/scenario-13/S03-API_Gateway_In_Istio_As_A_Service/README.md
@@ -60,12 +60,14 @@ This works in Istio permissive mode and Strict MTLS mode.
     ```
     >> apictl install api-operator
     Choose registry type:
-    1: Docker Hub (Or others, quay.io, HTTPS registry)
+    1: Docker Hub
     2: Amazon ECR
     3: GCR
     4: HTTP Private Registry
+    5: HTTPS Private Registry
+    6: Quay.io
     Choose a number: 1: 1
-    Enter repository name (docker.io/john | quay.io/mark | 10.100.5.225:5000/jennifer): docker.io/jennifer
+    Enter repository name: docker.io/jennifer
     Enter username: jennifer
     Enter password: *******
     


### PR DESCRIPTION
## Purpose
- Update WSO2AM, Analytics docker images and operator image
- Update build from source doc
- Change the version as "1.2.0-alpha
- Update documents with new apictl install api-operator command output
- Remove docker.io prefix for repository name of Docker Hub from docs
- Brake lines for long sentences
