### PR TITLE
Make Audience optional field in JWT

### DIFF
--- a/api-operator/deploy/controller-configs/default_security_cr.yaml
+++ b/api-operator/deploy/controller-configs/default_security_cr.yaml
@@ -24,7 +24,6 @@ spec:
   securityConfig:
     - certificate: wso2am310-secret
       issuer: https://wso2apim:32001/oauth2/token
-      audience: http://org.wso2.apimgt/gateway
       validateSubscription: false
 
 ---

--- a/api-operator/deploy/controller-configs/mgw_conf_mustache.yaml
+++ b/api-operator/deploy/controller-configs/mgw_conf_mustache.yaml
@@ -118,7 +118,9 @@ data:
     {{range .JwtConfigs}}
     [[jwtTokenConfig]]
       issuer = "{{.Issuer}}"
+      {{ if .AudiencePresent }}
       audience = "{{.Audience}}"
+      {{ end }}
       certificateAlias = "{{.CertificateAlias}}"
       # Validate subscribed APIs
       validateSubscription = {{.ValidateSubscription}}

--- a/api-operator/pkg/controller/security/security_controller.go
+++ b/api-operator/pkg/controller/security/security_controller.go
@@ -116,9 +116,12 @@ func (r *ReconcileSecurity) Reconcile(request reconcile.Request) (reconcile.Resu
 	userNamespace := instance.Namespace
 	if strings.EqualFold(instance.Spec.Type, "JWT") {
 		for _, securityConfig := range instance.Spec.SecurityConfig {
-			if securityConfig.Issuer == "" || securityConfig.Audience == "" {
+			if securityConfig.Issuer == "" {
 				reqLogger.Error(err, "Required fields are missing")
 				return reconcile.Result{}, err
+			}
+			if securityConfig.Audience == "" {
+				reqLogger.Info("Audience is not Provided")
 			}
 			certificateSecret := &corev1.Secret{}
 			errcertificate := r.client.Get(context.TODO(), types.NamespacedName{Name: securityConfig.Certificate, Namespace: userNamespace}, certificateSecret)

--- a/api-operator/pkg/mgw/config.go
+++ b/api-operator/pkg/mgw/config.go
@@ -145,6 +145,7 @@ type JwtTokenConfig struct {
 	Issuer               string
 	Audience             string
 	ValidateSubscription bool
+	AudiencePresent      bool
 }
 
 type APIKeyTokenConfig struct {
@@ -178,6 +179,7 @@ var Configs = &Configuration{
 			Issuer:               "https://wso2apim.wso2:32001/oauth2/token",
 			Audience:             "http://org.wso2.apimgt/gateway",
 			ValidateSubscription: false,
+			AudiencePresent:      false,
 		},
 	},
 

--- a/api-operator/pkg/security/security.go
+++ b/api-operator/pkg/security/security.go
@@ -124,6 +124,7 @@ func Handle(client *client.Client, securityMap map[string][]string, userNameSpac
 					jwtConf.Issuer = securityConf.Issuer
 				}
 				if securityConf.Audience != "" {
+					jwtConf.AudiencePresent = true
 					jwtConf.Audience = securityConf.Audience
 				}
 

--- a/scenarios/scenario-4/README.md
+++ b/scenarios/scenario-4/README.md
@@ -25,6 +25,7 @@
     security.wso2.com/petstorejwt created
     secret/wso2am310-secret created
     ```
+Note: ***audience*** field can be provided in Security custom resource(CR) under securityConfig field, if you have any.
 
 - Prepared petstore swagger definition can be found within this directory.
 

--- a/scenarios/scenario-4/jwt-security.yaml
+++ b/scenarios/scenario-4/jwt-security.yaml
@@ -23,7 +23,6 @@ spec:
   type: JWT
   securityConfig:
     - issuer: https://wso2apim:32001/oauth2/token
-      audience: http://org.wso2.apimgt/gateway
       #create secret with certificate and add secret name
       certificate: wso2am310-secret
       validateSubscription: false

--- a/scenarios/scenario-4/multiple-jwt-security.yaml
+++ b/scenarios/scenario-4/multiple-jwt-security.yaml
@@ -23,7 +23,6 @@ spec:
   type: JWT
   securityConfig:
     - issuer: https://wso2apim:32001/oauth2/token
-      audience: http://org.wso2.apimgt/gateway
       #create secret with certificate and add secret name
       certificate: wso2am310-secret
       validateSubscription: false


### PR DESCRIPTION
## Purpose

- This fixes  #398

## Goals

- Make the Audience field optional in JWT

## Approach

- Make the audience field which is in Security Custom Resource (CR) related to JWT optional.

- When an user needs to add audience value he/she can add it in the Security Custom Resource (CR) under security config with audience field.

- JWTs that are taken from the API Manager has an audience that keep changing based on the provider. So it is required to make the audience field optional.