### PR TITLE
Set API endpoint and refactor getting external IP

### DIFF
--- a/api-operator/pkg/mgw/service.go
+++ b/api-operator/pkg/mgw/service.go
@@ -25,6 +25,7 @@ import (
 )
 
 const (
+	defaultMode   = "Default"
 	ingressMode   = "Ingress"
 	routeMode     = "Route"
 	clusterIPMode = "ClusterIP"


### PR DESCRIPTION
fix wso2/k8s-api-operator#388

## Purpose
- Add ingress hostname if IP not found.

## Samples
```sh
$ kubectl get api
NAME           INITIAL-REPLICAS   MODE         ENDPOINT    AGE
petstore-api   1                  privateJet   localhost   2m46s
```