### PR TITLE
Update metrics configs for hpa version v2beta1

### DIFF
--- a/api-operator/deploy/controller-configs/controller_conf.yaml
+++ b/api-operator/deploy/controller-configs/controller_conf.yaml
@@ -128,13 +128,13 @@ data:
   jwtTokenExpiry: "900000"
   #Restricted claims as a list that should not be included in the backend JWT token
   jwtRestrictedClaims: |
-  # claim1  (This is an example)
+  # "claim1","claim2"
 
   #Token issuer standard claim
   jwtIssuer: "wso2.org/products/am"
   #Token audience standard claim as a list
   jwtAudience: |
-  # http://org.wso2.apimgt/gateway (This is an example)
+  # "http://org.wso2.apimgt/gateway"
 
   #JWT token generator implementation
   jwtGeneratorImpl: "org.wso2.micro.gateway.jwt.generator.MGWJWTGeneratorImpl"

--- a/api-operator/deploy/controller-configs/controller_conf.yaml
+++ b/api-operator/deploy/controller-configs/controller_conf.yaml
@@ -158,7 +158,7 @@ data:
   # Horizontal Pod Auto-Scaling for Micro-Gateways
   # Maximum number of replicas for the Horizontal Pod Auto-scale. Default->  maxReplicas: "5"
   mgwMaxReplicas: "5"
-  # Metrics configurations
+  # Metrics configurations for v2beta2
   mgwMetrics: |
     - type: Resource
       resource:
@@ -185,10 +185,17 @@ data:
     #       type: Value
     #       value: 10k
 
+  # Metrics Configurations for v2beta1
+  mgwMetricsV2beta1: |
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: 50
+
   # Horizontal Pod Auto-Scaling for Target-Endpoints
   # Maximum number of replicas for the Horizontal Pod Auto-scale. Default->  maxReplicas: "5"
   targetEndpointMaxReplicas: "5"
-  # Metrics configurations
+  # Metrics configurations for v2beta2
   targetEndpointMetrics: |
     - type: Resource
       resource:
@@ -196,6 +203,14 @@ data:
         target:
           type: Utilization
           averageUtilization: 50
+
+  # Metrics Configurations for v2beta1
+  targetEndpointMetricsV2beta1: |
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: 50
+
   # HPA version. For custom metrics HPA version should be v2beta2. Default-> v2beta1
   hpaVersion: "v2beta1"
 

--- a/api-operator/pkg/controller/targetendpoint/constants.go
+++ b/api-operator/pkg/controller/targetendpoint/constants.go
@@ -20,10 +20,11 @@ const (
 	privateJet         = "privateJet"
 	serverless         = "serverless"
 
-	hpaConfigMapName     = "hpa-configs"
-	maxReplicasConfigKey = "targetEndpointMaxReplicas"
-	metricsConfigKey     = "targetEndpointMetrics"
-	hpaVersionConst      = "hpaVersion"
+	hpaConfigMapName        = "hpa-configs"
+	maxReplicasConfigKey    = "targetEndpointMaxReplicas"
+	metricsConfigKey        = "targetEndpointMetrics"
+	metricsConfigKeyV2beta1 = "targetEndpointMetricsV2beta1"
+	hpaVersionConst         = "hpaVersion"
 
 	resourceRequestCPUTarget    = "resourceRequestCPUTarget"
 	resourceRequestMemoryTarget = "resourceRequestMemoryTarget"

--- a/api-operator/pkg/controller/targetendpoint/targetendpoint_controller.go
+++ b/api-operator/pkg/controller/targetendpoint/targetendpoint_controller.go
@@ -516,7 +516,7 @@ func createHPAv2beta1(client *client.Client, targetEp *wso2v1alpha1.TargetEndpoi
 
 	// parse hpa config yaml
 	var metricsHpa []v2beta1.MetricSpec
-	yamlErr := yaml.Unmarshal([]byte(hpaConfMap.Data[metricsConfigKey]), &metricsHpa)
+	yamlErr := yaml.Unmarshal([]byte(hpaConfMap.Data[metricsConfigKeyV2beta1]), &metricsHpa)
 	if yamlErr != nil {
 		log.Error(err, "Error marshalling HPA config yaml", "configmap", hpaConfMap)
 		return nil, yamlErr

--- a/api-operator/pkg/mgw/config.go
+++ b/api-operator/pkg/mgw/config.go
@@ -387,18 +387,22 @@ func SetApimConfigs(client *client.Client) error {
 	} else {
 		Configs.JwtTokenCacheExpiryTime = int32(jwtTokenCacheExpiryTime)
 	}
-	jwtRestrictedClaims := strings.Split(apimConfig.Data[jwtRestrictedClaimsConst], "\n")
-	for i, element := range jwtRestrictedClaims {
+	var jwtRestrictedClaims []string
+	jwtRestrictedClaimsArray := strings.Split(apimConfig.Data[jwtRestrictedClaimsConst], ",")
+	for _, element := range jwtRestrictedClaimsArray {
 		if element != "" {
-			Configs.JwtRestrictedClaims[i] = element
+			jwtRestrictedClaims = append(jwtRestrictedClaims, element)
 		}
 	}
-	jwtAudience := strings.Split(apimConfig.Data[jwtAudienceConst], "\n")
-	for i, element := range jwtAudience {
+	Configs.JwtRestrictedClaims = jwtRestrictedClaims
+	var jwtAudience []string
+	jwtAudienceArray := strings.Split(apimConfig.Data[jwtAudienceConst], ",")
+	for _, element := range jwtAudienceArray {
 		if element != "" {
-			Configs.JwtAudience[i] = element
+			jwtAudience = append(jwtAudience, element)
 		}
 	}
+	Configs.JwtAudience = jwtAudience
 	jwtTokenCacheCapacity, err := strconv.Atoi(apimConfig.Data[jwtTokenCacheCapacityConst])
 	if err != nil {
 		logConf.Error(err, "Provided JWT Token cache capacity is invalid. Using the default JWT token cache"+

--- a/api-operator/pkg/mgw/hpa.go
+++ b/api-operator/pkg/mgw/hpa.go
@@ -157,8 +157,9 @@ func ValidateHpaConfigs(client *client.Client) error {
 			return yamlErr
 		}
 	} else {
+		err = errors.New("invalid HPA Version")
 		logHpa.Error(err, "Error getting the HPA version. HPA version is invalid")
-		return errors.New("invalid HPA Version")
+		return err
 
 	}
 	return nil

--- a/api-operator/pkg/mgw/hpa.go
+++ b/api-operator/pkg/mgw/hpa.go
@@ -36,10 +36,11 @@ var metricsHpaV2beta2 *[]v2beta2.MetricSpec
 var hpaMaxReplicas int32
 
 const (
-	hpaConfigMapName     = "hpa-configs"
-	metricsConfigKey     = "mgwMetrics"
-	maxReplicasConfigKey = "mgwMaxReplicas"
-	hpaVersionConst      = "hpaVersion"
+	hpaConfigMapName        = "hpa-configs"
+	metricsConfigKey        = "mgwMetrics"
+	metricsConfigKeyV2beta1 = "mgwMetricsV2beta1"
+	maxReplicasConfigKey    = "mgwMaxReplicas"
+	hpaVersionConst         = "hpaVersion"
 )
 
 // HPA checks whether the HPA version is v2beta1 or v2beta2
@@ -140,7 +141,7 @@ func ValidateHpaConfigs(client *client.Client) error {
 	if hpaConfMap.Data[hpaVersionConst] == "v2beta1" {
 		// parse hpa config yaml
 		metricsHpaV2beta1 = []v2beta1.MetricSpec{}
-		yamlErr := yaml.Unmarshal([]byte(hpaConfMap.Data[metricsConfigKey]), metricsHpaV2beta1)
+		yamlErr := yaml.Unmarshal([]byte(hpaConfMap.Data[metricsConfigKeyV2beta1]), metricsHpaV2beta1)
 		if yamlErr != nil {
 			logHpa.Error(err, "Error marshalling HPA config yaml", "configmap", hpaConfMap)
 			return yamlErr

--- a/scenarios/scenario-20/README.md
+++ b/scenarios/scenario-20/README.md
@@ -189,7 +189,14 @@ as follows.
     #Expose custom metrics. Default-> observabilityEnabled: "false"
     observabilityEnabled: "true"
     ```
-  
+- Change the hpa version to "v2beta2" for custom metrics. Edit `<K8S_API_OPERATOR_HOME>controller-configs/controller_conf.yaml`
+ as follows.
+     ```yaml
+      # HPA version. For custom metrics HPA version should be v2beta2. Default-> v2beta1
+       hpaVersion: "v2beta2"
+     ```
+
+- Apply the changes
     ```sh
     >> apictl apply -f <K8S_API_OPERATOR_HOME>controller-configs/controller_conf.yaml
     ```


### PR DESCRIPTION
- This fixes some issues related to backend JWT Generation.
- Updates the metrics configurations for hpa versipn "v2beta1".
- When using custom metrics update the scenario-20 docs with regard to changing hpa version to "v2beta2"