### PR TITLE
Add support to mount config maps and secrets to mgw deployment

### DIFF
--- a/api-operator/deploy/controller-configs/controller_conf.yaml
+++ b/api-operator/deploy/controller-configs/controller_conf.yaml
@@ -292,3 +292,23 @@ data:
       - SOAPAction
       - apikey
       - Authorization
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mgw-deployment-configs
+  namespace: wso2-system
+data:
+  mgwConfigMaps: |
+  # Config Maps to be added to mgw deployment. This is an example
+  #  - name: test1cm
+  #    mountLocation: /home/ballerina/test1cm
+  #    subPath: test1cm
+  #    namespace: micro
+  mgwSecrets: |
+  # Secrets to be added to mgw deployment. This is an example
+  #  - name: test1secret
+  #    mountLocation: /home/ballerina/test1secret
+  #    subPath: test1secret
+  #    namespace: micro

--- a/api-operator/pkg/controller/api/api_controller.go
+++ b/api-operator/pkg/controller/api/api_controller.go
@@ -508,9 +508,16 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 	if deployMgwRuntime {
 		reqLogger.Info("Deploying MGW runtime image")
 		// create MGW deployment in k8s cluster
-		mgwDeployment := mgw.Deployment(&r.client, instance, controlConfigData, ownerRef)
+		mgwDeployment, errDeploy := mgw.Deployment(&r.client, instance, controlConfigData, ownerRef)
 		r.recorder.Event(instance, corev1.EventTypeNormal, "MGWRuntime",
 			fmt.Sprintf("Deploying MGW runtime: %s.", mgwDeployment.Name))
+		if errDeploy != nil {
+			reqLogger.Error(errDeploy, "Error mounting config maps and secrets to" +
+				"mgw deployment")
+			r.recorder.Event(instance, eventTypeError, "MGWDeployment", "Error mounting config maps and " +
+				"secrets to mgw deployment")
+			return reconcile.Result{}, errDeploy
+		}
 		if errMgw := k8s.Apply(&r.client, mgwDeployment); errMgw != nil {
 			reqLogger.Error(errMgw, "Error updating the MGW deployment", "deploy_name", mgwDeployment.Name)
 			r.recorder.Event(instance, eventTypeError, "MGWRuntime",

--- a/api-operator/pkg/controller/api/api_controller.go
+++ b/api-operator/pkg/controller/api/api_controller.go
@@ -508,7 +508,7 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 	if deployMgwRuntime {
 		reqLogger.Info("Deploying MGW runtime image")
 		// create MGW deployment in k8s cluster
-		mgwDeployment := mgw.Deployment(instance, controlConfigData, ownerRef)
+		mgwDeployment := mgw.Deployment(&r.client, instance, controlConfigData, ownerRef)
 		r.recorder.Event(instance, corev1.EventTypeNormal, "MGWRuntime",
 			fmt.Sprintf("Deploying MGW runtime: %s.", mgwDeployment.Name))
 		if errMgw := k8s.Apply(&r.client, mgwDeployment); errMgw != nil {

--- a/api-operator/pkg/k8s/mount.go
+++ b/api-operator/pkg/k8s/mount.go
@@ -72,3 +72,44 @@ func EmptyDirVolumeMount(volumeName string, mountPath string) (*corev1.Volume, *
 	}
 	return &vol, &mount
 }
+
+func MgwConfigDirVolumeMount(confMapName string, mountPath string, subPath string) (*corev1.Volume, *corev1.VolumeMount) {
+	volName := confMapName + "-vol"
+	vol := corev1.Volume{
+		Name: volName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: confMapName,
+				},
+			},
+		},
+	}
+	mount := corev1.VolumeMount{
+		Name:      volName,
+		MountPath: mountPath,
+		SubPath:   subPath,
+		ReadOnly:  false,
+	}
+	return &vol, &mount
+}
+
+func MgwSecretVolumeMount(secretName string, mountPath string, subPath string) (*corev1.Volume, *corev1.VolumeMount) {
+	volName := secretName + "-vol"
+	vol := corev1.Volume{
+		Name: volName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: secretName,
+			},
+		},
+	}
+	mount := corev1.VolumeMount{
+		Name:      volName,
+		MountPath: mountPath,
+		SubPath:   subPath,
+		ReadOnly:  false,
+	}
+
+	return &vol, &mount
+}

--- a/api-operator/pkg/mgw/deployment.go
+++ b/api-operator/pkg/mgw/deployment.go
@@ -20,11 +20,17 @@ import (
 	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/registry"
+	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"strconv"
 	"strings"
 )
@@ -48,6 +54,22 @@ const (
 	envKeyValSeparator = "="
 )
 
+// mgw-deployment-configs
+const (
+	mgwDeploymentConfigMapName = "mgw-deployment-configs"
+	mgwConfigMaps              = "mgwConfigMaps"
+	mgwSecrets                 = "mgwSecrets"
+)
+
+type DeploymentConfig struct {
+	Name          string `yaml:"name"`
+	MountLocation string `yaml:"mountLocation"`
+	SubPath       string `yaml:"subPath"`
+	Namespace     string `yaml:"namespace,omitempty"`
+}
+
+var logDeploy = log.Log.WithName("mgw.hpa")
+
 var (
 	ContainerList *[]corev1.Container
 )
@@ -62,11 +84,36 @@ func AddContainers(containers *[]corev1.Container) {
 }
 
 // Deployment returns a MGW deployment for the given API definition
-func Deployment(api *wso2v1alpha1.API, controlConfigData map[string]string, owner *[]metav1.OwnerReference) *appsv1.Deployment {
+func Deployment(client *client.Client, api *wso2v1alpha1.API, controlConfigData map[string]string,
+	owner *[]metav1.OwnerReference) *appsv1.Deployment {
 	regConfig := registry.GetConfig()
 	labels := map[string]string{"app": api.Name}
 	var deployVolume []corev1.Volume
 	var deployVolumeMount []corev1.VolumeMount
+	var mgwDeployVol *v1.Volume
+	var mgwDeployMount *v1.VolumeMount
+	mgwDeploymentConfMap := k8s.NewConfMap()
+	errGetDeploy := k8s.Get(client, types.NamespacedName{Name: mgwDeploymentConfigMapName, Namespace: api.Namespace}, mgwDeploymentConfMap)
+	if errGetDeploy != nil && errors.IsNotFound(errGetDeploy) {
+		logDeploy.Info("Get mgw deployment configs", "from namespace", wso2NameSpaceConst)
+		//retrieve mgw deployment configs from wso2-system namespace
+		err := k8s.Get(client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: mgwDeploymentConfigMapName},
+			mgwDeploymentConfMap)
+		if err != nil {
+			logDeploy.Error(err, "MGW Deployment configs not defined")
+			return nil
+		}
+	} else if errGetDeploy != nil {
+		logDeploy.Error(errGetDeploy, "Error getting mgw deployment configs from user namespace")
+	} else {
+		//retrieve mgw deployment configs from user namespace
+		err := k8s.Get(client, types.NamespacedName{Namespace: api.Namespace, Name: mgwDeploymentConfigMapName},
+			mgwDeploymentConfMap)
+		if err != nil {
+			logDeploy.Error(err, "MGW Deployment configs not defined")
+			return nil
+		}
+	}
 
 	liveDelay, _ := strconv.ParseInt(controlConfigData[livenessProbeInitialDelaySeconds], 10, 32)
 	livePeriod, _ := strconv.ParseInt(controlConfigData[livenessProbePeriodSeconds], 10, 32)
@@ -85,6 +132,74 @@ func Deployment(api *wso2v1alpha1.API, controlConfigData map[string]string, owne
 		deployVolume = append(deployVolume, *analVol)
 		deployVolumeMount = append(deployVolumeMount, *analMount)
 	}
+
+	var deploymentConfigMaps []DeploymentConfig
+	yamlErrDeploymentConfigMaps := yaml.Unmarshal([]byte(mgwDeploymentConfMap.Data[mgwConfigMaps]), &deploymentConfigMaps)
+	if yamlErrDeploymentConfigMaps != nil {
+		logHpa.Error(yamlErrDeploymentConfigMaps, "Error marshalling mgw config maps yaml",
+			"configmap", mgwDeploymentConfMap)
+	}
+	var deploymentSecrets []DeploymentConfig
+	yamlErrDeploymentSecrets := yaml.Unmarshal([]byte(mgwDeploymentConfMap.Data[mgwSecrets]), &deploymentSecrets)
+	if yamlErrDeploymentSecrets != nil {
+		logHpa.Error(yamlErrDeploymentSecrets, "Error marshalling mgw secrets yaml", "configmap",
+			mgwDeploymentConfMap)
+	}
+	// mount the MGW config maps to volume
+	for _, deploymentConfigMap := range deploymentConfigMaps {
+		if deploymentConfigMap.Namespace == "" {
+			mgwConfigMap := k8s.NewConfMap()
+			mgwConfigMapErr := k8s.Get(client, types.NamespacedName{Namespace: mgwDeploymentConfMap.Namespace,
+				Name: deploymentConfigMap.Name}, mgwConfigMap)
+			if mgwConfigMapErr != nil {
+				logDeploy.Error(mgwConfigMapErr, "Error Getting the mgw Config map")
+			}
+			newMgwConfigMap := CopyMgwConfigMap(types.NamespacedName{Namespace: api.Namespace,
+				Name: deploymentConfigMap.Name}, mgwConfigMap)
+			createConfigMapErr := k8s.Apply(client, newMgwConfigMap)
+			if createConfigMapErr != nil {
+				logDeploy.Error(createConfigMapErr, "Error Copying mgw config map to user namespace")
+			}
+			mgwDeployVol, mgwDeployMount = k8s.MgwConfigDirVolumeMount(deploymentConfigMap.Name,
+				deploymentConfigMap.MountLocation, deploymentConfigMap.SubPath)
+			deployVolume = append(deployVolume, *mgwDeployVol)
+			deployVolumeMount = append(deployVolumeMount, *mgwDeployMount)
+		} else if strings.EqualFold(deploymentConfigMap.Namespace, api.Namespace) {
+			mgwDeployVol, mgwDeployMount = k8s.MgwConfigDirVolumeMount(deploymentConfigMap.Name,
+				deploymentConfigMap.MountLocation, deploymentConfigMap.SubPath)
+			deployVolume = append(deployVolume, *mgwDeployVol)
+			deployVolumeMount = append(deployVolumeMount, *mgwDeployMount)
+		}
+	}
+	// mount MGW secrets to volume
+	for _, deploymentSecret := range deploymentSecrets {
+		if deploymentSecret.Namespace == "" {
+			mgwSecret := k8s.NewSecret()
+			mgwSecretErr := k8s.Get(client, types.NamespacedName{Namespace: mgwDeploymentConfMap.Namespace,
+				Name: deploymentSecret.Name}, mgwSecret)
+			if mgwSecretErr != nil {
+				logDeploy.Error(mgwSecretErr, "Error Getting the mgw Secret")
+			}
+			newMgwSecret := CopyMgwSecret(types.NamespacedName{Namespace: api.Namespace,
+				Name: deploymentSecret.Name}, mgwSecret)
+			createSecretErr := k8s.Apply(client, newMgwSecret)
+			if createSecretErr != nil {
+				logDeploy.Error(createSecretErr, "Error Copying mgw secret to user namespace")
+			}
+			mgwDeployVol, mgwDeployMount = k8s.MgwSecretVolumeMount(deploymentSecret.Name,
+				deploymentSecret.MountLocation,
+				deploymentSecret.SubPath)
+			deployVolume = append(deployVolume, *mgwDeployVol)
+			deployVolumeMount = append(deployVolumeMount, *mgwDeployMount)
+		} else if strings.EqualFold(deploymentSecret.Namespace, api.Namespace) {
+			mgwDeployVol, mgwDeployMount = k8s.MgwSecretVolumeMount(deploymentSecret.Name,
+				deploymentSecret.MountLocation,
+				deploymentSecret.SubPath)
+			deployVolume = append(deployVolume, *mgwDeployVol)
+			deployVolumeMount = append(deployVolumeMount, *mgwDeployMount)
+		}
+	}
+
 	req := corev1.ResourceList{
 		corev1.ResourceCPU:    resource.MustParse(resReqCPU),
 		corev1.ResourceMemory: resource.MustParse(resReqMemory),
@@ -194,4 +309,22 @@ func Deployment(api *wso2v1alpha1.API, controlConfigData map[string]string, owne
 		},
 	}
 	return deploy
+}
+
+// CopyMgwConfigMap returns a copied configMap object with given namespacedName
+func CopyMgwConfigMap(namespacedName types.NamespacedName, confMap *corev1.ConfigMap) *corev1.ConfigMap {
+	confMap.ObjectMeta = metav1.ObjectMeta{
+		Name:      namespacedName.Name,
+		Namespace: namespacedName.Namespace,
+	}
+	return confMap
+}
+
+// CopyMgwSecret returns a copied secret object with given namespacedName
+func CopyMgwSecret(namespacedName types.NamespacedName, secret *corev1.Secret) *corev1.Secret {
+	secret.ObjectMeta = metav1.ObjectMeta{
+		Name:      namespacedName.Name,
+		Namespace: namespacedName.Namespace,
+	}
+	return secret
 }

--- a/api-operator/pkg/mgw/deployment.go
+++ b/api-operator/pkg/mgw/deployment.go
@@ -20,17 +20,12 @@ import (
 	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/registry"
-	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"strconv"
 	"strings"
 )
@@ -54,22 +49,6 @@ const (
 	envKeyValSeparator = "="
 )
 
-// mgw-deployment-configs
-const (
-	mgwDeploymentConfigMapName = "mgw-deployment-configs"
-	mgwConfigMaps              = "mgwConfigMaps"
-	mgwSecrets                 = "mgwSecrets"
-)
-
-type DeploymentConfig struct {
-	Name          string `yaml:"name"`
-	MountLocation string `yaml:"mountLocation"`
-	SubPath       string `yaml:"subPath"`
-	Namespace     string `yaml:"namespace,omitempty"`
-}
-
-var logDeploy = log.Log.WithName("mgw.deployment")
-
 var (
 	ContainerList *[]corev1.Container
 )
@@ -88,26 +67,6 @@ func Deployment(client *client.Client, api *wso2v1alpha1.API, controlConfigData 
 	owner *[]metav1.OwnerReference) (*appsv1.Deployment, error) {
 	regConfig := registry.GetConfig()
 	labels := map[string]string{"app": api.Name}
-	var deployVolume []corev1.Volume
-	var deployVolumeMount []corev1.VolumeMount
-	var mgwDeployVol *v1.Volume
-	var mgwDeployMount *v1.VolumeMount
-	mgwDeploymentConfMap := k8s.NewConfMap()
-	errGetDeploy := k8s.Get(client, types.NamespacedName{Name: mgwDeploymentConfigMapName, Namespace: api.Namespace}, mgwDeploymentConfMap)
-	if errGetDeploy != nil && errors.IsNotFound(errGetDeploy) {
-		logDeploy.Info("Get mgw deployment configs", "from namespace", wso2NameSpaceConst)
-		//retrieve mgw deployment configs from wso2-system namespace
-		err := k8s.Get(client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: mgwDeploymentConfigMapName},
-			mgwDeploymentConfMap)
-		if err != nil && !errors.IsNotFound(err) {
-			logDeploy.Error(err, "MGW Deployment configs not defined")
-			return nil, err
-		}
-	} else if errGetDeploy != nil {
-		logDeploy.Error(errGetDeploy, "Error getting mgw deployment configs from user namespace")
-		return nil, errGetDeploy
-	}
-
 	liveDelay, _ := strconv.ParseInt(controlConfigData[livenessProbeInitialDelaySeconds], 10, 32)
 	livePeriod, _ := strconv.ParseInt(controlConfigData[livenessProbePeriodSeconds], 10, 32)
 	readDelay, _ := strconv.ParseInt(controlConfigData[readinessProbeInitialDelaySeconds], 10, 32)
@@ -119,80 +78,15 @@ func Deployment(client *client.Client, api *wso2v1alpha1.API, controlConfigData 
 	resLimitCPU := controlConfigData[resourceLimitCPU]
 	resLimitMemory := controlConfigData[resourceLimitMemory]
 
+	// Mount the user specified Config maps and secrets to mgw deploy volume
+	deployVolume, deployVolumeMount, errDeploy := UserDeploymentVolume(client, api)
+
 	if Configs.AnalyticsEnabled {
 		// mounts an empty dir volume to be used when analytics is enabled
 		analVol, analMount := k8s.EmptyDirVolumeMount("analytics", analyticsLocation)
 		deployVolume = append(deployVolume, *analVol)
 		deployVolumeMount = append(deployVolumeMount, *analMount)
 	}
-
-	var deploymentConfigMaps []DeploymentConfig
-	yamlErrDeploymentConfigMaps := yaml.Unmarshal([]byte(mgwDeploymentConfMap.Data[mgwConfigMaps]), &deploymentConfigMaps)
-	if yamlErrDeploymentConfigMaps != nil {
-		logDeploy.Error(yamlErrDeploymentConfigMaps, "Error marshalling mgw config maps yaml",
-			"configmap", mgwDeploymentConfMap)
-	}
-	var deploymentSecrets []DeploymentConfig
-	yamlErrDeploymentSecrets := yaml.Unmarshal([]byte(mgwDeploymentConfMap.Data[mgwSecrets]), &deploymentSecrets)
-	if yamlErrDeploymentSecrets != nil {
-		logDeploy.Error(yamlErrDeploymentSecrets, "Error marshalling mgw secrets yaml", "configmap",
-			mgwDeploymentConfMap)
-	}
-	// mount the MGW config maps to volume
-	for _, deploymentConfigMap := range deploymentConfigMaps {
-		if deploymentConfigMap.Namespace == "" {
-			mgwConfigMap := k8s.NewConfMap()
-			mgwConfigMapErr := k8s.Get(client, types.NamespacedName{Namespace: mgwDeploymentConfMap.Namespace,
-				Name: deploymentConfigMap.Name}, mgwConfigMap)
-			if mgwConfigMapErr != nil {
-				logDeploy.Error(mgwConfigMapErr, "Error Getting the mgw Config map")
-			}
-			newMgwConfigMap := CopyMgwConfigMap(types.NamespacedName{Namespace: api.Namespace,
-				Name: deploymentConfigMap.Name}, mgwConfigMap)
-			createConfigMapErr := k8s.Apply(client, newMgwConfigMap)
-			if createConfigMapErr != nil {
-				logDeploy.Error(createConfigMapErr, "Error Copying mgw config map to user namespace")
-			}
-			mgwDeployVol, mgwDeployMount = k8s.MgwConfigDirVolumeMount(deploymentConfigMap.Name,
-				deploymentConfigMap.MountLocation, deploymentConfigMap.SubPath)
-			deployVolume = append(deployVolume, *mgwDeployVol)
-			deployVolumeMount = append(deployVolumeMount, *mgwDeployMount)
-		} else if strings.EqualFold(deploymentConfigMap.Namespace, api.Namespace) {
-			mgwDeployVol, mgwDeployMount = k8s.MgwConfigDirVolumeMount(deploymentConfigMap.Name,
-				deploymentConfigMap.MountLocation, deploymentConfigMap.SubPath)
-			deployVolume = append(deployVolume, *mgwDeployVol)
-			deployVolumeMount = append(deployVolumeMount, *mgwDeployMount)
-		}
-	}
-	// mount MGW secrets to volume
-	for _, deploymentSecret := range deploymentSecrets {
-		if deploymentSecret.Namespace == "" {
-			mgwSecret := k8s.NewSecret()
-			mgwSecretErr := k8s.Get(client, types.NamespacedName{Namespace: mgwDeploymentConfMap.Namespace,
-				Name: deploymentSecret.Name}, mgwSecret)
-			if mgwSecretErr != nil {
-				logDeploy.Error(mgwSecretErr, "Error Getting the mgw Secret")
-			}
-			newMgwSecret := CopyMgwSecret(types.NamespacedName{Namespace: api.Namespace,
-				Name: deploymentSecret.Name}, mgwSecret)
-			createSecretErr := k8s.Apply(client, newMgwSecret)
-			if createSecretErr != nil {
-				logDeploy.Error(createSecretErr, "Error Copying mgw secret to user namespace")
-			}
-			mgwDeployVol, mgwDeployMount = k8s.MgwSecretVolumeMount(deploymentSecret.Name,
-				deploymentSecret.MountLocation,
-				deploymentSecret.SubPath)
-			deployVolume = append(deployVolume, *mgwDeployVol)
-			deployVolumeMount = append(deployVolumeMount, *mgwDeployMount)
-		} else if strings.EqualFold(deploymentSecret.Namespace, api.Namespace) {
-			mgwDeployVol, mgwDeployMount = k8s.MgwSecretVolumeMount(deploymentSecret.Name,
-				deploymentSecret.MountLocation,
-				deploymentSecret.SubPath)
-			deployVolume = append(deployVolume, *mgwDeployVol)
-			deployVolumeMount = append(deployVolumeMount, *mgwDeployMount)
-		}
-	}
-
 	req := corev1.ResourceList{
 		corev1.ResourceCPU:    resource.MustParse(resReqCPU),
 		corev1.ResourceMemory: resource.MustParse(resReqMemory),
@@ -301,23 +195,5 @@ func Deployment(client *client.Client, api *wso2v1alpha1.API, controlConfigData 
 			},
 		},
 	}
-	return deploy, nil
-}
-
-// CopyMgwConfigMap returns a copied configMap object with given namespacedName
-func CopyMgwConfigMap(namespacedName types.NamespacedName, confMap *corev1.ConfigMap) *corev1.ConfigMap {
-	confMap.ObjectMeta = metav1.ObjectMeta{
-		Name:      namespacedName.Name,
-		Namespace: namespacedName.Namespace,
-	}
-	return confMap
-}
-
-// CopyMgwSecret returns a copied secret object with given namespacedName
-func CopyMgwSecret(namespacedName types.NamespacedName, secret *corev1.Secret) *corev1.Secret {
-	secret.ObjectMeta = metav1.ObjectMeta{
-		Name:      namespacedName.Name,
-		Namespace: namespacedName.Namespace,
-	}
-	return secret
+	return deploy, errDeploy
 }

--- a/api-operator/pkg/mgw/uservolumes.go
+++ b/api-operator/pkg/mgw/uservolumes.go
@@ -1,0 +1,143 @@
+package mgw
+
+import (
+	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
+	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"strings"
+)
+
+// mgw-deployment-configs
+const (
+	mgwDeploymentConfigMapName = "mgw-deployment-configs"
+	mgwConfigMaps              = "mgwConfigMaps"
+	mgwSecrets                 = "mgwSecrets"
+)
+
+type DeploymentConfig struct {
+	Name          string `yaml:"name"`
+	MountLocation string `yaml:"mountLocation"`
+	SubPath       string `yaml:"subPath"`
+	Namespace     string `yaml:"namespace,omitempty"`
+}
+
+var logDeploy = log.Log.WithName("mgw.userDeploymentVolume")
+
+// UserDeploymentVolume returns the deploy volumes and volume mounts with user defined config maps and secrets
+func UserDeploymentVolume(client *client.Client, api *wso2v1alpha1.API) ([]corev1.Volume, []corev1.VolumeMount,
+	error) {
+	var deployVolume []corev1.Volume
+	var deployVolumeMount []corev1.VolumeMount
+	var mgwDeployVol *v1.Volume
+	var mgwDeployMount *v1.VolumeMount
+	mgwDeploymentConfMap := k8s.NewConfMap()
+	errGetDeploy := k8s.Get(client, types.NamespacedName{Name: mgwDeploymentConfigMapName, Namespace: api.Namespace},
+		mgwDeploymentConfMap)
+	if errGetDeploy != nil && errors.IsNotFound(errGetDeploy) {
+		logDeploy.Info("Get mgw deployment configs", "from namespace", wso2NameSpaceConst)
+		//retrieve mgw deployment configs from wso2-system namespace
+		err := k8s.Get(client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: mgwDeploymentConfigMapName},
+			mgwDeploymentConfMap)
+		if err != nil && !errors.IsNotFound(err) {
+			logDeploy.Error(err, "MGW Deployment configs not defined")
+			return nil, nil, err
+		}
+	} else if errGetDeploy != nil {
+		logDeploy.Error(errGetDeploy, "Error getting mgw deployment configs from user namespace")
+		return nil, nil, errGetDeploy
+	}
+
+	var deploymentConfigMaps []DeploymentConfig
+	yamlErrDeploymentConfigMaps := yaml.Unmarshal([]byte(mgwDeploymentConfMap.Data[mgwConfigMaps]), &deploymentConfigMaps)
+	if yamlErrDeploymentConfigMaps != nil {
+		logDeploy.Error(yamlErrDeploymentConfigMaps, "Error marshalling mgw config maps yaml",
+			"configmap", mgwDeploymentConfMap)
+	}
+	var deploymentSecrets []DeploymentConfig
+	yamlErrDeploymentSecrets := yaml.Unmarshal([]byte(mgwDeploymentConfMap.Data[mgwSecrets]), &deploymentSecrets)
+	if yamlErrDeploymentSecrets != nil {
+		logDeploy.Error(yamlErrDeploymentSecrets, "Error marshalling mgw secrets yaml", "configmap",
+			mgwDeploymentConfMap)
+	}
+	// mount the MGW config maps to volume
+	for _, deploymentConfigMap := range deploymentConfigMaps {
+		if deploymentConfigMap.Namespace == "" {
+			mgwConfigMap := k8s.NewConfMap()
+			mgwConfigMapErr := k8s.Get(client, types.NamespacedName{Namespace: mgwDeploymentConfMap.Namespace,
+				Name: deploymentConfigMap.Name}, mgwConfigMap)
+			if mgwConfigMapErr != nil {
+				logDeploy.Error(mgwConfigMapErr, "Error Getting the mgw Config map")
+			}
+			newMgwConfigMap := CopyMgwConfigMap(types.NamespacedName{Namespace: api.Namespace,
+				Name: deploymentConfigMap.Name}, mgwConfigMap)
+			createConfigMapErr := k8s.Apply(client, newMgwConfigMap)
+			if createConfigMapErr != nil {
+				logDeploy.Error(createConfigMapErr, "Error Copying mgw config map to user namespace")
+			}
+			mgwDeployVol, mgwDeployMount = k8s.MgwConfigDirVolumeMount(deploymentConfigMap.Name,
+				deploymentConfigMap.MountLocation, deploymentConfigMap.SubPath)
+			deployVolume = append(deployVolume, *mgwDeployVol)
+			deployVolumeMount = append(deployVolumeMount, *mgwDeployMount)
+		} else if strings.EqualFold(deploymentConfigMap.Namespace, api.Namespace) {
+			mgwDeployVol, mgwDeployMount = k8s.MgwConfigDirVolumeMount(deploymentConfigMap.Name,
+				deploymentConfigMap.MountLocation, deploymentConfigMap.SubPath)
+			deployVolume = append(deployVolume, *mgwDeployVol)
+			deployVolumeMount = append(deployVolumeMount, *mgwDeployMount)
+		}
+	}
+	// mount MGW secrets to volume
+	for _, deploymentSecret := range deploymentSecrets {
+		if deploymentSecret.Namespace == "" {
+			mgwSecret := k8s.NewSecret()
+			mgwSecretErr := k8s.Get(client, types.NamespacedName{Namespace: mgwDeploymentConfMap.Namespace,
+				Name: deploymentSecret.Name}, mgwSecret)
+			if mgwSecretErr != nil {
+				logDeploy.Error(mgwSecretErr, "Error Getting the mgw Secret")
+			}
+			newMgwSecret := CopyMgwSecret(types.NamespacedName{Namespace: api.Namespace,
+				Name: deploymentSecret.Name}, mgwSecret)
+			createSecretErr := k8s.Apply(client, newMgwSecret)
+			if createSecretErr != nil {
+				logDeploy.Error(createSecretErr, "Error Copying mgw secret to user namespace")
+			}
+			mgwDeployVol, mgwDeployMount = k8s.MgwSecretVolumeMount(deploymentSecret.Name,
+				deploymentSecret.MountLocation,
+				deploymentSecret.SubPath)
+			deployVolume = append(deployVolume, *mgwDeployVol)
+			deployVolumeMount = append(deployVolumeMount, *mgwDeployMount)
+		} else if strings.EqualFold(deploymentSecret.Namespace, api.Namespace) {
+			mgwDeployVol, mgwDeployMount = k8s.MgwSecretVolumeMount(deploymentSecret.Name,
+				deploymentSecret.MountLocation,
+				deploymentSecret.SubPath)
+			deployVolume = append(deployVolume, *mgwDeployVol)
+			deployVolumeMount = append(deployVolumeMount, *mgwDeployMount)
+		}
+	}
+	return deployVolume, deployVolumeMount, nil
+
+}
+
+// CopyMgwConfigMap returns a copied configMap object with given namespacedName
+func CopyMgwConfigMap(namespacedName types.NamespacedName, confMap *corev1.ConfigMap) *corev1.ConfigMap {
+	confMap.ObjectMeta = metav1.ObjectMeta{
+		Name:      namespacedName.Name,
+		Namespace: namespacedName.Namespace,
+	}
+	return confMap
+}
+
+// CopyMgwSecret returns a copied secret object with given namespacedName
+func CopyMgwSecret(namespacedName types.NamespacedName, secret *corev1.Secret) *corev1.Secret {
+	secret.ObjectMeta = metav1.ObjectMeta{
+		Name:      namespacedName.Name,
+		Namespace: namespacedName.Namespace,
+	}
+	return secret
+}

--- a/api-operator/pkg/mgw/uservolumes.go
+++ b/api-operator/pkg/mgw/uservolumes.go
@@ -62,7 +62,7 @@ func UserDeploymentVolume(client *client.Client, api *wso2v1alpha1.API) ([]corev
 		err := k8s.Get(client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: mgwDeploymentConfigMapName},
 			mgwDeploymentConfMap)
 		if err != nil && !errors.IsNotFound(err) {
-			logDeploy.Error(err, "MGW Deployment configs not defined")
+			logDeploy.Error(err, "Error while reading user volumes config")
 			return nil, nil, err
 		}
 	} else if errGetDeploy != nil {

--- a/api-operator/pkg/mgw/uservolumes.go
+++ b/api-operator/pkg/mgw/uservolumes.go
@@ -1,3 +1,19 @@
+// Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package mgw
 
 import (

--- a/scenarios/scenario-23/README.md
+++ b/scenarios/scenario-23/README.md
@@ -1,0 +1,172 @@
+## Scenario 23 - Add Config Maps and Secrets to Micro-gateway Deployment
+
+- This scenario describes how to add or mount the desired config maps and secrets to micro-gateway deployment.
+
+ ***Important:***
+> Follow the main README and deploy the api-operator and configuration files. Make sure to set the analyticsEnabled to "true" and deploy analytics secret with credentials to analytics server and certificate, if you want to check analytics.
+
+##### Deploying the artifacts 
+
+- Create a namespace as "micro".
+  ```
+  >> apictl create ns micro
+      
+  Output:
+  namespace/micro created    
+  ```
+- Navigate to scenarios/scenario-23 directory.
+
+- Create and deploy the config maps and secrets that you need to mount. In here
+`test1cm` config map is in "wso2-system" namespace. `test2cm` config map and `test1secret` 
+secret are in "micro" namespace.
+  ```$xslt
+  >> apictl apply -f test1cm.yaml
+  >> apictl apply -f test2cm.yaml
+  >> apictl apply -f test1secret.yaml     
+   
+  Output:
+  configmap/test1cm created
+  configmap/test2cm created
+  secret/test1secret created
+  ```
+  
+#### Approach 01
+
+- Micro-gateway Deployment Configurations can be configured in the mgw-deployment-configs in `controller-configs/controller_conf.yaml`
+
+     ```
+      mgwConfigMaps: |
+        - name: test1cm
+          mountLocation: /home/ballerina/test1cm
+          subPath: test1cm
+      mgwSecrets: |
+        - name: test1secret
+          mountLocation: /home/ballerina/test1secret
+          subPath: test1secret
+          namespace: micro
+     ```
+- In this configuration you can provide: 
+    - name of the config map or secret.
+    - location that you need to mount the config map or secret.
+    - sub path of the mount location. 
+    - namespace of the config map or secret. This field is an optional field.
+    When namespace is not provided, the config map or secret should be created in the same namespace
+    which the mgw-deployment-configs are deployed. In this case `test1cm` is deployed in
+    "wso2-system" namespace. 
+
+***Important:***
+> If you create an API in another namespace (Eg: foo) then, only config maps or secrets which a namespace
+>is not specified under mgw-deployment-configs (Eg: test1cm) will be mounted. 
+
+- Apply the changes
+    ```$xslt
+    >> apictl apply -f <k8s-api-operator-home>/api-operator/controller-artifacts/controller_conf.yaml
+    ```
+  
+- Execute the following to expose pet-store service as an API.
+
+- Create API <br /> 
+    ```
+    >> apictl add api -n petstore-api --from-file=swagger.yaml --override --namespace=micro
+        
+    Output:
+    creating configmap with swagger definition
+    configmap/petstore-api-swagger created
+    creating API definition
+    api.wso2.com/petstore-api created
+    ``` 
+    Note: ***--override*** flag is used to you want to rebuild the API image even if it exists in the configured docker repository.
+
+- Get the pods 
+    ```
+    >> apictl get pods -n micro
+            
+    Output:
+    NAME                            READY   STATUS      RESTARTS   AGE
+    petstore-api-5fcf4d4cc8-fbczp   1/1     Running     0          7m42s
+    ```
+
+- Describe the pods. You can see the config map and the secret has been mounted.
+    ```
+    Mounts:
+       /home/ballerina/test1cm from test1cm-vol (rw,path="test1cm")
+       /home/ballerina/test1secret from test1secret-vol (rw,path="test1secret")
+    ```
+
+- Delete the  API
+    - Following command will delete all the artifacts created with this API including pods, deployment and services.
+        ```
+        >> apictl delete api petstore-api -n micro
+        
+        Output:
+        api.wso2.com "petstore-api" deleted
+        ```
+      
+#### Approach 02
+
+- You can create and deploy `mgw-deployment-configs` config map in the same namespace that the API is being deployed 
+without altering the mgw-deployment-configs in `controller-configs/controller_conf.yaml`
+    ```  
+    >> apictl apply -f mgw-deploy-configs.yaml
+    
+    Output:
+    configmap/mgw-deployment-configs created
+    ```
+
+- In this configuration you can provide: 
+    - name of the config map or secret.
+    - location that you need to mount the config map or secret.
+    - sub path of the mount location. 
+    - namespace of the config map or secret. This field is an optional field.
+    When namespace is not provided, the config map or secret should be created in the namespace
+    which the mgw-deployment-configs are deployed. In this case `test1secret` secret is deployed in
+    "micro" namespace.
+    
+- Execute the following to expose pet-store service as an API.
+
+- Create API <br /> 
+    ```
+    >> apictl add api -n petstore-api --from-file=swagger.yaml --override --namespace=micro
+        
+    Output:
+    creating configmap with swagger definition
+    configmap/petstore-api-swagger created
+    creating API definition
+    api.wso2.com/petstore-api created
+    ``` 
+    Note: ***--override*** flag is used to you want to rebuild the API image even if it exists in the configured docker repository.
+
+- Get the pods 
+    ```
+    >> apictl get pods 
+            
+    Output:
+    NAME                            READY   STATUS      RESTARTS   AGE
+    petstore-api-5fcf4d4cc8-fbczp   1/1     Running     0          7m42s
+    ```
+
+- Describe the pods. You can see the config maps and the secrets have been mounted.
+    ```
+    Mounts:
+       /home/ballerina/test1secret from test1secret-vol (rw,path="test1secret")
+       /home/ballerina/test2cm from test2cm-vol (rw,path="test2cm")
+    ```
+
+- Delete the  API
+    - Following command will delete all the artifacts created with this API including pods, deployment and services.
+        ```
+        >> apictl delete api petstore-api -n micro
+        
+        Output:
+        api.wso2.com "petstore-api" deleted
+        ```
+
+- Delete config maps and secrets.
+    ```
+    >> apictl delete ns micro
+    >> apictl delete configmap test1cm -n wso2-system
+               
+    Output:
+    namespace "micro" deleted
+    configmap "test1cm" deleted
+    ```

--- a/scenarios/scenario-23/mgw-deploy-configs.yaml
+++ b/scenarios/scenario-23/mgw-deploy-configs.yaml
@@ -1,0 +1,31 @@
+#Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mgw-deployment-configs
+  namespace: micro
+data:
+  mgwConfigMaps: |
+    - name: test2cm
+      mountLocation: /home/ballerina/test2cm
+      subPath: test2cm
+      namespace: micro
+  mgwSecrets: |
+    - name: test1secret
+      mountLocation: /home/ballerina/test1secret
+      subPath: test1secret

--- a/scenarios/scenario-23/swagger.yaml
+++ b/scenarios/scenario-23/swagger.yaml
@@ -1,0 +1,187 @@
+#Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+openapi: 3.0.0
+servers:
+  - url: https://petstore.swagger.io/v2
+  - url: http://petstore.swagger.io/v2
+info:
+  description: 'This is a sample server Petstore server.  You can find out more about
+    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For
+    this sample, you can use the api key `special-key` to test the authorization filters.'
+  version: v1
+  title: Petstore-API
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+x-wso2-basePath: /petstore/{version}
+x-wso2-production-endpoints:
+  urls:
+    - https://petstore.swagger.io/v2
+paths:
+  "/pet/findByStatus":
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+              default: available
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+        '400':
+          description: Invalid status value
+  "/pet/{petId}":
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+components:
+  schemas:
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Category
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          "$ref": "#/components/schemas/Category"
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            "$ref": "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/Pet"
+        application/xml:
+          schema:
+            "$ref": "#/components/schemas/Pet"
+      description: Pet object that needs to be added to the store
+      required: true

--- a/scenarios/scenario-23/test1cm.yaml
+++ b/scenarios/scenario-23/test1cm.yaml
@@ -1,0 +1,23 @@
+#Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test1cm
+  namespace: wso2-system
+data:
+  exampleConfigMap: test1cm

--- a/scenarios/scenario-23/test1secret.yaml
+++ b/scenarios/scenario-23/test1secret.yaml
@@ -1,0 +1,26 @@
+#Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test1secret
+  namespace: micro
+type: Opaque
+data:
+  #username = password = admin
+  username: YWRtaW4=
+  password: YWRtaW4=

--- a/scenarios/scenario-23/test2cm.yaml
+++ b/scenarios/scenario-23/test2cm.yaml
@@ -1,0 +1,23 @@
+#Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test2cm
+  namespace: micro
+data:
+  exampleConfigMap: test2cm


### PR DESCRIPTION
## Purpose

- Add support to mount config maps and secrets to micro-gateway deployment.

## Approach
> Approach 01

- User can add **mgw-deployment-configs** to controller_conf.yaml and provide the config maps and secrets to be added to micro-gateway deployment.
- The config maps and secrets to be added need to be in the same namespace which the **mgw-deployment-configs** is being deployed.

> Approach 02

- User can create and deploy a **mgw-deployment-configs** config map in the same namespace which the API is being deployed and in there he/she can provide the config maps and secrets to be added to micro-gateway deployment.
- The config maps and secrets to be added need to be in the same namespace which the **mgw-deployment-configs**  is being deployed.
