### PR TITLE
Apply multiple jwt issuer configs in default security to mgw conf

### DIFF
--- a/api-operator/pkg/controller/api/api_controller.go
+++ b/api-operator/pkg/controller/api/api_controller.go
@@ -354,7 +354,8 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 		if !isDefinedSecurity && resourceLevelSec == 0 {
 			log.Info("Use default security")
 
-			err := security.Default(&r.client, userNamespace, ownerRef)
+			defaultJwtConfArray, err := security.Default(&r.client, userNamespace, ownerRef)
+			mgw.Configs.JwtConfigs = defaultJwtConfArray
 			if err != nil {
 				return reconcile.Result{}, err
 			}


### PR DESCRIPTION
## Purpose

- This fixes #426
- When the user provides multiple jwt issuers in the default security Custom Resource (CR) it will be applied to the micro-gateway conf. 
