### PR TITLE
Add components.extensions when it is not defined in swagger definition

### DIFF
--- a/api-operator/deploy/controller-artifacts/operator.yaml
+++ b/api-operator/deploy/controller-artifacts/operator.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
         - name: api-operator
           # Replace this with the built image name
-          image: renukafernando/k8s-api-operator:1.2.0-v6
+          image: renukafernando/k8s-api-operator:1.2.0-v7
           command:
           - api-operator
           imagePullPolicy: Always

--- a/api-operator/pkg/controller/api/api_controller.go
+++ b/api-operator/pkg/controller/api/api_controller.go
@@ -321,9 +321,17 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 		}
 		mgw.Configs.JwtConfigs = jwtConfArray
 		mgw.Configs.APIKeyConfigs = apiKeyConfArray
+
 		//adding security scheme to swagger
 		if len(securityDefinition) > 0 {
-			swaggerDoc.Components.Extensions[swagger.SecuritySchemeExtension] = securityDefinition
+			if swaggerDoc.Components.Extensions != nil {
+				swaggerDoc.Components.Extensions[swagger.SecuritySchemeExtension] = securityDefinition
+			} else {
+				// Components.Extensions not defined in swagger document
+				swaggerDoc.Components.Extensions = map[string]interface{}{
+					swagger.SecuritySchemeExtension: securityDefinition,
+				}
+			}
 		}
 		// mount formatted swagger to kaniko job
 		formattedSwagger := swagger.PrettyString(swaggerDoc)


### PR DESCRIPTION
Add components.extensions when it is not defined in swagger definition
fix wso2/k8s-api-operator#444