### PR TITLE
Fix issue in checking image existence in GCR, Docker Hub, ECR

### DIFF
--- a/api-operator/deploy/controller-artifacts/operator.yaml
+++ b/api-operator/deploy/controller-artifacts/operator.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
         - name: api-operator
           # Replace this with the built image name
-          image: renukafernando/k8s-api-operator:1.2.0-v7
+          image: renukafernando/k8s-api-operator:1.2.0-v8
           command:
           - api-operator
           imagePullPolicy: Always

--- a/api-operator/pkg/registry/http.go
+++ b/api-operator/pkg/registry/http.go
@@ -36,7 +36,7 @@ func getHttpRegConfigFunc(repoName string, imgName string, tag string) *Config {
 	httpReg.IsImageExist = func(config *Config, auth utils.RegAuth, image string, tag string) (b bool, err error) {
 		auth.RegistryUrl = strings.Replace(auth.RegistryUrl, "https://", "http://", 1)
 		logger.Info("Checking for image in HTTP registry", "Registry URL", auth.RegistryUrl)
-		return utils.IsImageExists(auth, image, tag)
+		return utils.IsImageExists(auth, getImageWithoutReg(image), tag)
 	}
 
 	return &httpReg


### PR DESCRIPTION
## Purpose
- Fix issue in checking image existence in GCR, DockerHub, ECR
- A fix has done for HTTP/HTTPS private registry has applied for all other registries, so done this only for HTTP/HTTPS registries.
- Move `getImageWithoutReg` to HTTP/HTTPS private registries.