### PR TITLE
Add image pull secret for pulling Kaniko image

### DIFF
--- a/api-operator/pkg/kaniko/job.go
+++ b/api-operator/pkg/kaniko/job.go
@@ -89,8 +89,9 @@ func Job(api *wso2v1alpha1.API, controlConfigData map[string]string, kanikoArgs 
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsUser: &rootUserVal,
 					},
-					RestartPolicy: "Never",
-					Volumes:       *JobVolume,
+					RestartPolicy:    "Never",
+					Volumes:          *JobVolume,
+					ImagePullSecrets: regConfig.ImagePullSecrets,
 				},
 			},
 		},


### PR DESCRIPTION
fix wso2/k8s-api-operator#451

## Purpose
Add image pull secret for pulling Kaniko image

## Tested Procedure
- Created a docker registry with auth configs (`192.168.8.132:5000`).
- Images
  - `192.168.8.132:5000/wso2am/wso2micro-gw-toolkit:3.2.0-rc2`
  - `192.168.8.132:5000/wso2/wso2micro-gw:3.2.0-rc2`
  - `192.168.8.132:5000/gcr.io/kaniko-project/executor:v0.24.0`
- Push images to the registry
- Docker rmi images (removed above images)
- Install API Operator with following config
    ```
    data:
    #mgw toolkit image to initialize/setup the micro gw project
    mgwToolkitImg: 192.168.8.132:5000/wso2am/wso2micro-gw-toolkit:3.2.0-rc2
    #mgw runtime image to use in the mgw executable
    mgwRuntimeImg: 192.168.8.132:5000/wso2/wso2micro-gw:3.2.0-rc2
    #kaniko image for the kaniko pod which builds the mgw api runtime and pushes to the registry
    kanikoImg: 192.168.8.132:5000/gcr.io/kaniko-project/executor:v0.24.0
    ```
- Add API
    ```
    kubectl get po
    NAME                        READY   STATUS    RESTARTS   AGE
    petstore-api-kaniko-j8n6t   1/1     Running   0          28s

    kubectl get po
    NAME                            READY   STATUS      RESTARTS   AGE
    petstore-api-585f7ff9c9-9pnzm   1/1     Running     0          5m
    petstore-api-kaniko-j8n6t       0/1     Completed   0          6m3s
    ```