### PR TITLE
[1.3.x] Preventing JWT token issuers getting overridden in shared mode

### DIFF
--- a/api-operator/pkg/controller/api/api_controller.go
+++ b/api-operator/pkg/controller/api/api_controller.go
@@ -277,6 +277,7 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 	}
 
 	swaggerCmNames := instance.Spec.Definition.SwaggerConfigmapNames
+	apiSecurityConfigs := []mgw.JwtTokenConfig{}
 	for i, swaggerCmName := range swaggerCmNames {
 		// Check if the configmap mentioned in the crd object exist
 		swaggerConfMap := k8s.NewConfMap()
@@ -346,7 +347,9 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 		if errSec != nil {
 			return reconcile.Result{}, errSec
 		}
-		mgw.Configs.JwtConfigs = jwtConfArray
+		for _, jwtConf := range *jwtConfArray {
+			apiSecurityConfigs = append(apiSecurityConfigs, jwtConf)
+		}
 		mgw.Configs.APIKeyConfigs = apiKeyConfArray
 
 		//adding security scheme to swagger
@@ -397,12 +400,16 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 			reqLogger.Info("Use default security")
 
 			defaultJwtConfArray, err := security.Default(&r.client, userNamespace, ownerRef, artifactNs)
-			mgw.Configs.JwtConfigs = defaultJwtConfArray
+			for _, secConf := range *defaultJwtConfArray {
+				apiSecurityConfigs = append(apiSecurityConfigs, secConf)
+			}
 			if err != nil {
 				return reconcile.Result{}, err
 			}
 		}
 	}
+	//setting the JWT configs for API
+	mgw.Configs.JwtConfigs = &apiSecurityConfigs
 
 	// micro-gateway image to be build
 	mgwDockerImage.Name = strings.ToLower(strings.ReplaceAll(instance.Name, " ", ""))

--- a/api-operator/pkg/mgw/config.go
+++ b/api-operator/pkg/mgw/config.go
@@ -217,7 +217,7 @@ var Configs = &Configuration{
 	// jwtTokenConfig
 	JwtConfigs: &[]JwtTokenConfig{
 		{
-			CertificateAlias:     "wso2apim310",
+			CertificateAlias:     "wso2apim320",
 			Issuer:               "https://wso2apim.wso2:32001/oauth2/token",
 			Audience:             "http://org.wso2.apimgt/gateway",
 			ValidateSubscription: false,


### PR DESCRIPTION
### Purpose

This PR fixes an issue where JWT token issuers are overridden when there are multiple issuers in the shared mode.
Fixes https://github.com/wso2/k8s-api-operator/issues/453
