### PR TITLE
Preventing JWT token issuers getting overridden in shared mode

### DIFF
--- a/api-operator/pkg/mgw/config.go
+++ b/api-operator/pkg/mgw/config.go
@@ -217,7 +217,7 @@ var Configs = &Configuration{
 	// jwtTokenConfig
 	JwtConfigs: &[]JwtTokenConfig{
 		{
-			CertificateAlias:     "wso2apim310",
+			CertificateAlias:     "wso2apim320",
 			Issuer:               "https://wso2apim.wso2:32001/oauth2/token",
 			Audience:             "http://org.wso2.apimgt/gateway",
 			ValidateSubscription: false,


### PR DESCRIPTION
### Purpose
This PR fixes an issue where JWT token issuers are overridden when there are multiple issuers in the shared mode.
Fixes https://github.com/wso2/k8s-api-operator/issues/453
