### PR TITLE
HostAlias support for Operator

### DIFF
--- a/api-operator/deploy/controller-configs/controller_conf.yaml
+++ b/api-operator/deploy/controller-configs/controller_conf.yaml
@@ -306,6 +306,12 @@ metadata:
   name: mgw-deployment-configs
   namespace: wso2-system
 data:
+  hostAliases: |
+  #  Host Alises to be added to mgw deployment. This is an example.
+  #  - ip: "192.168.1.4"
+  #    hostnames:
+  #    - "wso2km"
+  #    - "km.wso2.com"
   mgwConfigMaps: |
   # Config Maps to be added to mgw deployment. This is an example
   #  - name: test1cm

--- a/api-operator/pkg/mgw/api.go
+++ b/api-operator/pkg/mgw/api.go
@@ -19,6 +19,7 @@ package mgw
 import (
 	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
@@ -101,4 +102,22 @@ func ExternalIP(client *client.Client, apiInstance *wso2v1alpha1.API, operatorMo
 
 	logger.Info("Setting API endpoint value", "api.endpoint", ipString)
 	return ipString
+}
+
+// get hostAliases for the deployment
+func getHostAliases(client *client.Client) []corev1.HostAlias {
+	mgwDeploymentConfMap := k8s.NewConfMap()
+	errGetDeploy := k8s.Get(client, types.NamespacedName{Name: mgwDeploymentConfigMapName, Namespace: wso2NameSpaceConst},
+		mgwDeploymentConfMap)
+	if errGetDeploy != nil {
+		logEp.Error(errGetDeploy, "Error getting mgw deployment configs")
+	}
+
+	var aliases []corev1.HostAlias
+	yamlErrDeploymentConfigMaps := yaml.Unmarshal([]byte(mgwDeploymentConfMap.Data["hostAliases"]), &aliases)
+	if yamlErrDeploymentConfigMaps != nil {
+		logEp.Error(yamlErrDeploymentConfigMaps, "Error setting the hostAliases")
+	}
+
+	return aliases
 }

--- a/api-operator/pkg/mgw/deployment.go
+++ b/api-operator/pkg/mgw/deployment.go
@@ -172,6 +172,9 @@ func Deployment(client *client.Client, api *wso2v1alpha1.API, controlConfigData 
 
 	*(ContainerList) = append(*(ContainerList), apiContainer)
 
+	// set hostAliases
+	hostAliases := getHostAliases(client)
+
 	deploy := k8s.NewDeployment()
 	deploy.ObjectMeta = metav1.ObjectMeta{
 		Name:            api.Name,
@@ -189,6 +192,7 @@ func Deployment(client *client.Client, api *wso2v1alpha1.API, controlConfigData 
 				Labels: labels,
 			},
 			Spec: corev1.PodSpec{
+				HostAliases:	  hostAliases,
 				Containers:       *(ContainerList),
 				Volumes:          deployVolume,
 				ImagePullSecrets: regConfig.ImagePullSecrets,


### PR DESCRIPTION
### Purpose
This PR adds hostAlias support of Operator which allows pod/deployment level override of hostname resolution when DNS and other options are not applicable.

Host Aliases can be defined under `mgw-deployment-configs`.

```
hostAliases: |
    - ip: "34.23.234.43"
      hostnames:
      - "wso2km"
      - "km.wso2.com"
```
Fixes https://github.com/wso2/k8s-api-operator/issues/466