### PR TITLE
Do not use global variable for containerslist

### DIFF
--- a/api-operator/pkg/endpoints/sidecar.go
+++ b/api-operator/pkg/endpoints/sidecar.go
@@ -18,6 +18,7 @@ package endpoints
 
 import (
 	"errors"
+
 	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/mgw"
@@ -38,7 +39,7 @@ const (
 
 var logger = log.Log.WithName("endpoints.sidecar")
 
-func AddSidecarContainers(client *client.Client, apiNamespace string, sidecarEpNames *map[string]bool) error {
+func AddSidecarContainers(client *client.Client, apiNamespace string, sidecarEpNames *map[string]bool, containersList *[]corev1.Container) error {
 	containerList := make([]corev1.Container, 0, len(*sidecarEpNames))
 	isAdded := make(map[string]bool)
 
@@ -69,13 +70,12 @@ func AddSidecarContainers(client *client.Client, apiNamespace string, sidecarEpN
 					return err
 				}
 
-
 				sidecarContainer := corev1.Container{
 					Image: targetEndpointCr.Spec.Deploy.DockerImage,
 					Name:  targetEndpointCr.Spec.Deploy.Name,
 					Ports: containerPorts,
 					Resources: corev1.ResourceRequirements{
-						Limits: resourceLimits,
+						Limits:   resourceLimits,
 						Requests: resourceRequirements,
 					},
 				}
@@ -95,7 +95,7 @@ func AddSidecarContainers(client *client.Client, apiNamespace string, sidecarEpN
 		}
 	}
 
-	mgw.AddContainers(&containerList)
+	mgw.AddContainers(containersList, &containerList)
 	return nil
 }
 

--- a/api-operator/pkg/endpoints/sidecar.go
+++ b/api-operator/pkg/endpoints/sidecar.go
@@ -21,7 +21,6 @@ import (
 
 	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
-	"github.com/wso2/k8s-api-operator/api-operator/pkg/mgw"
 	corev1 "k8s.io/api/core/v1"
 	k8sError "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -39,7 +38,7 @@ const (
 
 var logger = log.Log.WithName("endpoints.sidecar")
 
-func AddSidecarContainers(client *client.Client, apiNamespace string, sidecarEpNames *map[string]bool, containersList *[]corev1.Container) error {
+func GetSidecarContainers(client *client.Client, apiNamespace string, sidecarEpNames *map[string]bool) ([]corev1.Container, error) {
 	containerList := make([]corev1.Container, 0, len(*sidecarEpNames))
 	isAdded := make(map[string]bool)
 
@@ -64,10 +63,10 @@ func AddSidecarContainers(client *client.Client, apiNamespace string, sidecarEpN
 					if k8sError.IsNotFound(err) {
 						// Controller configmap is not found.
 						logger.Error(err, "Controller configuration file is not found")
-						return err
+						return nil, err
 					}
 					// Error reading the object
-					return err
+					return nil, err
 				}
 
 				sidecarContainer := corev1.Container{
@@ -90,13 +89,12 @@ func AddSidecarContainers(client *client.Client, apiNamespace string, sidecarEpN
 				}
 
 				logger.Error(err, "Failed to deploy the sidecar endpoint", "endpoint_name", sidecarEpName)
-				return err
+				return nil, err
 			}
 		}
 	}
 
-	mgw.AddContainers(containersList, &containerList)
-	return nil
+	return containerList, nil
 }
 
 func getResourceMetadata(client *client.Client,


### PR DESCRIPTION
## Purpose

Resolves #468 

## Goals

Create a local instance of the containersList for each call to the reconcile loop, instead of using the same global one.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Use local instance of ContainersList

## Documentation

N/A

