### PR TITLE
Create environment variables from ConfigMap / Secret

### DIFF
--- a/api-operator/deploy/controller-configs/controller_conf.yaml
+++ b/api-operator/deploy/controller-configs/controller_conf.yaml
@@ -318,9 +318,13 @@ data:
   #    mountLocation: /home/ballerina/test1cm
   #    subPath: test1cm
   #    namespace: micro
+  #  - name: test1cmEnv
+  #    asEnvVar: true
   mgwSecrets: |
   # Secrets to be added to mgw deployment. This is an example
   #  - name: test1secret
   #    mountLocation: /home/ballerina/test1secret
   #    subPath: test1secret
   #    namespace: micro
+  #  - name: test1secretEnv
+  #    asEnvVar: true

--- a/api-operator/pkg/k8s/mount.go
+++ b/api-operator/pkg/k8s/mount.go
@@ -113,3 +113,23 @@ func MgwSecretVolumeMount(secretName string, mountPath string, subPath string) (
 
 	return &vol, &mount
 }
+
+func MgwEnvFromConfigMap(name string) *corev1.EnvFromSource {
+	return &corev1.EnvFromSource{
+		ConfigMapRef: &corev1.ConfigMapEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: name,
+			},
+		},
+	}
+}
+
+func MgwEnvFromSecret(name string) *corev1.EnvFromSource {
+	return &corev1.EnvFromSource{
+		SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: name,
+			},
+		},
+	}
+}

--- a/api-operator/pkg/mgw/deployment.go
+++ b/api-operator/pkg/mgw/deployment.go
@@ -67,7 +67,7 @@ func Deployment(client *client.Client, api *wso2v1alpha1.API, controlConfigData 
 	resLimitMemory := controlConfigData[resourceLimitMemory]
 
 	// Mount the user specified Config maps and secrets to mgw deploy volume
-	deployVolume, deployVolumeMount, errDeploy := UserDeploymentVolume(client, api)
+	deployVolume, deployVolumeMount, envFromSources, errDeploy := UserDeploymentVolume(client, api)
 
 	if Configs.AnalyticsEnabled {
 		// mounts an empty dir volume to be used when analytics is enabled
@@ -131,6 +131,7 @@ func Deployment(client *client.Client, api *wso2v1alpha1.API, controlConfigData 
 		},
 		VolumeMounts: deployVolumeMount,
 		Env:          env,
+		EnvFrom:      envFromSources,
 		Ports:        containerPorts,
 		ReadinessProbe: &corev1.Probe{
 			Handler: corev1.Handler{


### PR DESCRIPTION
## Purpose

Related to #470 

## Goals

A new boolean field `asEnvVar` has been added in the structure of the mgw-deployment-configs configmap. 

If this field is true for a ConfigMap or Secret, the values in the ConfigMap / secrets will be declared as environment variables instead of mounting the configmap / secret as a volume.


## Samples

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: mgw-deployment-configs
  namespace: micro
data:
  mgwConfigMaps: |
    - name: test2cm
      mountLocation: /home/ballerina/test2cm
      subPath: test2cm
      namespace: micro
    - name: test2cmEnv
      asEnvVar: true
  mgwSecrets: |
    - name: test1secret
      mountLocation: /home/ballerina/test1secret
      subPath: test1secret
    - name: test1secretEnv
      asEnvVar: true
```

## Migrations (if applicable)

N/A
