### PR TITLE
x-wso2-endpoints support for Operator

### DIFF
--- a/api-operator/pkg/swagger/extensions.go
+++ b/api-operator/pkg/swagger/extensions.go
@@ -27,12 +27,13 @@ import (
 var logExt = log.Log.WithName("swagger.extensions")
 
 const (
-	EndpointExtension       = "x-wso2-production-endpoints"
-	ApiBasePathExtension    = "x-wso2-basePath"
-	DeploymentModeExtension = "x-wso2-mode"
-	SecurityExtension       = "security"
-	PathsExtension          = "paths"
-	SecuritySchemeExtension = "securitySchemes"
+	EndpointExtension 			= "x-wso2-endpoints"
+	ProductionEndpointExtension = "x-wso2-production-endpoints"
+	ApiBasePathExtension    	= "x-wso2-basePath"
+	DeploymentModeExtension 	= "x-wso2-mode"
+	SecurityExtension       	= "security"
+	PathsExtension          	= "paths"
+	SecuritySchemeExtension 	= "securitySchemes"
 )
 
 func ApiBasePath(swagger *openapi3.Swagger) string {


### PR DESCRIPTION
### Purpose
This PR adds `x-wso2-endpoints` support for the Operator. With this, we can define endpoints in the swagger definition in the following format.
```
x-wso2-production-endpoints: "#/x-wso2-endpoints/myEndpoint1" 
x-wso2-endpoints:
  - myEndpoint1:
     urls:
       - https://petstore.swagger.io/v2
```

Scenarios tested: 1,2,7,8
Fixes https://github.com/wso2/k8s-api-operator/issues/473
Related issues: https://github.com/wso2/k8s-api-operator/issues/415, https://github.com/wso2/k8s-api-operator/issues/352
