### PR TITLE
Allow user to configure name of secret with credentials to registry and allow to use different registry for pull and push

### DIFF
--- a/api-operator/pkg/controller/api/api_controller.go
+++ b/api-operator/pkg/controller/api/api_controller.go
@@ -19,10 +19,11 @@ package api
 import (
 	"context"
 	"fmt"
-	"github.com/wso2/k8s-api-operator/api-operator/pkg/config"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/wso2/k8s-api-operator/api-operator/pkg/config"
 
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/analytics"
 	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
@@ -166,7 +167,7 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 	controlConf := k8s.NewConfMap()
 	errConf := k8s.Get(&r.client, types.NamespacedName{Namespace: config.SystemNamespace, Name: controllerConfName},
 		controlConf)
-	//get docker registry configs
+	//get pull docker registry configs
 	dockerRegistryConf := k8s.NewConfMap()
 	errRegConf := k8s.Get(&r.client, types.NamespacedName{Namespace: config.SystemNamespace, Name: dockerRegConfigs},
 		dockerRegistryConf)
@@ -210,6 +211,22 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 	mgwDockerImage.RegistryType = registry.Type(dockerRegistryConf.Data[registryTypeConst])
 	mgwDockerImage.RepositoryName = dockerRegistryConf.Data[repositoryNameConst]
 	operatorMode := controlConfigData[operatorModeConst]
+
+	//optional get push docker registry configs
+	dockerPushRegistryConf := k8s.NewConfMap()
+	if controlConfigData[dockerPushRegName] != "" {
+		k8s.Get(&r.client, types.NamespacedName{Namespace: config.SystemNamespace, Name: controlConfigData[dockerPushRegName]},
+			dockerPushRegistryConf)
+
+		registryPushTypeStr := dockerPushRegistryConf.Data[registryTypeConst]
+		if !registry.IsRegistryType(registryPushTypeStr) {
+			reqLogger.Error(err, "Invalid push registry type. Requeue request after 10 seconds",
+				"registry-type", registryPushTypeStr)
+			// Registry type is invalid, user should update this with valid type.
+			// Return and requeue
+			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+	}
 
 	// log controller configurations
 	reqLogger.Info(
@@ -426,6 +443,18 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 		return reconcile.Result{}, errReg
 	}
 
+	//If push registry is set
+	if dockerPushRegistryConf != nil {
+		mgwDockerImage.RegistryType = registry.Type(dockerPushRegistryConf.Data[registryTypeConst])
+		mgwDockerImage.RepositoryName = dockerPushRegistryConf.Data[repositoryNameConst]
+
+		errReg := registry.SetRegistry(&r.client, userNamespace, mgwDockerImage)
+		if errReg != nil {
+			reqLogger.Error(errReg, "Error setting docker push registry", "docker_image", mgwDockerImage)
+			return reconcile.Result{}, errReg
+		}
+	}
+
 	// if Spec.Image is supplied do not need to build the image (i.e. don't run kaniko job)
 	if instance.Spec.Image != "" {
 		reqLogger.Info("Image is specified in the in API CRD. Skipping the kaniko job")
@@ -536,6 +565,12 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 					reqLogger.Info("Kaniko job is completed successfully", "job_status", kanikoJob.Status)
 					r.recorder.Event(instance, corev1.EventTypeNormal, "KanikoJob",
 						"Kaniko job completed successfully.")
+
+					//If Job is completed and we use special Push registry we must rewrite MGW image back to pull registry
+					if dockerPushRegistryConf != nil {
+						mgwDockerImage.RegistryType = registry.Type(dockerRegistryConf.Data[registryTypeConst])
+						mgwDockerImage.RepositoryName = dockerRegistryConf.Data[repositoryNameConst]
+					}
 				}
 			}
 		}

--- a/api-operator/pkg/controller/api/constants.go
+++ b/api-operator/pkg/controller/api/constants.go
@@ -27,6 +27,9 @@ const (
 	dockerRegConfigs    = "docker-registry-config"
 	kanikoArgsConfigs   = "kaniko-arguments"
 
+	dockerPushRegName        = "pushRegistryName"
+	imagePullSecretNameConst = "imagePullSecretName"
+
 	operatorModeConst             = "operatorMode"
 	istioMode                     = "Istio"
 	ingressMode                   = "Ingress"

--- a/api-operator/pkg/kaniko/job.go
+++ b/api-operator/pkg/kaniko/job.go
@@ -34,7 +34,9 @@ import (
 var logJob = log.Log.WithName("kaniko.job")
 
 const (
-	kanikoImgConst = "kanikoImg"
+	kanikoImgConst           = "kanikoImg"
+	imagePushSecretNameConst = "imagePushSecretName"
+	dockerRegCredVolumeName  = "reg-secret-volume"
 )
 
 // Job returns a kaniko job with mounted volumes
@@ -46,6 +48,10 @@ func Job(api *wso2v1alpha1.API, controlConfigData map[string]string, kanikoArgs 
 	}
 
 	regConfig := registry.GetImageConfig(image)
+	pushSecret := controlConfigData[imagePushSecretNameConst]
+	if pushSecret != "" {
+		regConfig.Volumes[0].VolumeSource.Secret.SecretName = pushSecret
+	}
 	AddVolumes(&regConfig.Volumes, &regConfig.VolumeMounts)
 
 	kanikoImg := controlConfigData[kanikoImgConst]

--- a/api-operator/pkg/registry/dockerhub.go
+++ b/api-operator/pkg/registry/dockerhub.go
@@ -53,7 +53,7 @@ func getDockerHubConfigFunc(repoName string, imgName string, tag string) *Config
 			},
 		},
 		ImagePullSecrets: []corev1.LocalObjectReference{
-			{Name: utils.DockerRegCredSecret},
+			{Name: DockerPullSecretName},
 		},
 		ImagePath: fmt.Sprintf("%s/%s:%s", repoName, imgName, tag),
 	}

--- a/api-operator/pkg/registry/dockerhub.go
+++ b/api-operator/pkg/registry/dockerhub.go
@@ -38,7 +38,7 @@ func getDockerHubConfigFunc(repoName string, imgName string, tag string) *Config
 		},
 		Volumes: []corev1.Volume{
 			{
-				Name: "reg-secret-volume",
+				Name: utils.DockerRegCredVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
 						SecretName: utils.DockerRegCredSecret,

--- a/api-operator/pkg/registry/registry.go
+++ b/api-operator/pkg/registry/registry.go
@@ -60,6 +60,8 @@ type Config struct {
 		tag string) (bool, error) // Function to check the already existence of the image
 }
 
+var DockerPullSecretName = utils.DockerRegCredSecret
+
 // registry details
 var registryConfigs = map[Type]func(repoName string, imgName string, tag string) *Config{}
 

--- a/api-operator/pkg/registry/utils/consts.go
+++ b/api-operator/pkg/registry/utils/consts.go
@@ -18,6 +18,7 @@ package utils
 
 const DockerConfigKeyConst = ".dockerconfigjson"
 const DockerRegCredSecret = "docker-registry-credentials"
+const DockerRegCredVolumeName = "reg-secret-volume"
 
 const AmazonCredHelperConfMap = "amazon-credential-helper"
 const AwsCredentialsSecret = "aws-credentials"


### PR DESCRIPTION
## Purpose
In our corporation we use an internal docker registry (Nexus3). In the registry we store our internal images and use it as proxy for images from public sources. We divide our registry to two. One is only for pulling and contains all internal images and all images through proxy. Second is used for pushing to our internal store and is unable to pull through proxied registries.

We also have our internal private cloud with K8s clusters where we want to use API Operator. In these clusters images can be pulled only from our internal registry and they cannot connect to internet directly. In each cluster is already defined secret with registry pull credentials.

https://github.com/wso2/k8s-api-operator/issues/463

## Goals
You can optionally configure your name of secret with pull credentials instead of usage of default "docker-registry-credentials". You can also configure different configMap and secret for push.

## Approach
I added a new Image type variable to registry.go for push. The variable is used only when configuration with name for push repository is present. A new configuration with pull secret name is used only if it's present otherwise default name is used.

## Release note
Allow configuration of different pull and push registry with secrets.