### PR TITLE
Ability to configure all throttling endpoints

### DIFF
--- a/api-operator/deploy/controller-configs/controller_conf.yaml
+++ b/api-operator/deploy/controller-configs/controller_conf.yaml
@@ -92,6 +92,8 @@ data:
   #Message broker connection URL (related to distributed ratelimiting and token revocation)
   #Format: hostname_of_API_Portal:JMS_port
   jmsConnectionProvider: "wso2apim.wso2:5672"
+  throttlingRecieverUrl: "wso2apim.wso2:9611"
+  throttlingAuthUrl: "wso2apim.wso2:9711"
   #Token revocation
   #Enable real time notifier for token revocation
   enableRealtimeMessageRetrieval: "false"

--- a/api-operator/deploy/controller-configs/mgw_conf_mustache.yaml
+++ b/api-operator/deploy/controller-configs/mgw_conf_mustache.yaml
@@ -313,8 +313,8 @@ data:
         password = "{{$.ApimPassword}}"
         # Receiver URL and the authentication URL of the Traffic manager node/nodes
         [[throttlingConfig.binary.URLGroup]]
-          receiverURL = "tcp://wso2apim.wso2:9611"
-          authURL = "ssl://wso2apim.wso2:9711"
+          receiverURL = "tcp://{{$.ThrottlingRecieverURL}}"
+          authURL = "ssl://{{$.ThrottlingAuthURL}}"
         # Data publisher object pool configurations
         [throttlingConfig.binary.publisherPool]
           maxIdle = 1000

--- a/api-operator/pkg/mgw/config.go
+++ b/api-operator/pkg/mgw/config.go
@@ -17,6 +17,9 @@
 package mgw
 
 import (
+	"strconv"
+	"strings"
+
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/kaniko"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/str"
@@ -26,8 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"strconv"
-	"strings"
 )
 
 var logConf = log.Log.WithName("mgw.config")
@@ -61,10 +62,12 @@ const (
 	enabledGlobalTMEventPublishingConst = "enabledGlobalTMEventPublishing"
 	jmsConnectionProviderConst          = "jmsConnectionProvider"
 	throttleEndpointConst               = "throttleEndpoint"
+	throttlingRecieverURLConst          = "throttlingRecieverUrl"
+	throttlingAuthURLConst              = "throttlingAuthUrl"
 	enableRealtimeMessageRetrievalConst = "enableRealtimeMessageRetrieval"
 	enableRequestValidationConst        = "enableRequestValidation"
 	enableResponseValidationConst       = "enableResponseValidation"
-	enabledEventhub						= "enabledEventhub"
+	enabledEventhub                     = "enabledEventhub"
 	logLevelConst                       = "logLevel"
 	httpPortConst                       = "httpPort"
 	httpsPortConst                      = "httpsPort"
@@ -126,6 +129,8 @@ type Configuration struct {
 	ThrottleEndpoint               string
 	ApimUsername                   string
 	ApimPassword                   string
+	ThrottlingRecieverURL          string
+	ThrottlingAuthURL              string
 
 	// token revocation
 	EnableRealtimeMessageRetrieval string
@@ -133,7 +138,7 @@ type Configuration struct {
 	// validation
 	EnableRequestValidation  string
 	EnableResponseValidation string
-	EnabledEventhub			 string
+	EnabledEventhub          string
 
 	//basic authentication
 	BasicUsername string
@@ -241,6 +246,8 @@ var Configs = &Configuration{
 	ThrottleEndpoint:               "wso2apim.wso2:32001",
 	ApimUsername:                   "admin",
 	ApimPassword:                   "admin",
+	ThrottlingRecieverURL:          "wso2apim.wso2:9611",
+	ThrottlingAuthURL:              "wso2apim.wso2:9611",
 
 	// token revocation
 	EnableRealtimeMessageRetrieval: "false",
@@ -248,7 +255,7 @@ var Configs = &Configuration{
 	// validation
 	EnableRequestValidation:  "false",
 	EnableResponseValidation: "false",
-	EnabledEventhub: 		  "false",
+	EnabledEventhub:          "false",
 
 	//basic authentication
 	BasicUsername: "admin",
@@ -332,6 +339,8 @@ func SetApimConfigs(client *client.Client) error {
 	Configs.ThrottleEndpoint = apimConfig.Data[throttleEndpointConst]
 	Configs.ApimUsername = string(apimSecret.Data["username"])
 	Configs.ApimPassword = string(apimSecret.Data["password"])
+	Configs.ThrottlingRecieverURL = apimConfig.Data[throttlingRecieverURLConst]
+	Configs.ThrottlingAuthURL = apimConfig.Data[throttlingAuthURLConst]
 	Configs.EnableRealtimeMessageRetrieval = apimConfig.Data[enableRealtimeMessageRetrievalConst]
 	Configs.EnableRequestValidation = apimConfig.Data[enableRequestValidationConst]
 	Configs.EnableResponseValidation = apimConfig.Data[enableResponseValidationConst]


### PR DESCRIPTION
## Purpose
Operator has throttling configuration in two places. In apim_conf.yaml and in mgw_conf_mustache.yaml where are hard coded values for two endpoints.

## Goals
I want to be able to configure all throttling endpoints in one place.

## Approach
I added new configuration parameters to be able configure all throttling endpoints in one place.