### PR TITLE
[1.2.x] Set system namespace with the environment variable "SYSTEM_NAMESPACE"

### DIFF
--- a/api-operator/cmd/manager/main.go
+++ b/api-operator/cmd/manager/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	operatorConfig "github.com/wso2/k8s-api-operator/api-operator/pkg/config"
 	v1 "k8s.io/api/core/v1"
 	"os"
 	"runtime"
@@ -59,6 +60,13 @@ func main() {
 	// be propagated through the whole operator, generating
 	// uniform and structured logs.
 	logf.SetLogger(zap.Logger())
+
+	// Set system and operator namespaces
+	if found := operatorConfig.SetSystemNamespaceFromEnv(); !found {
+		log.Info("Environment variable for system namespace not defined and using the default",
+			"env_var", operatorConfig.SystemNamespaceEnv, "default_ns", operatorConfig.DefaultSystemNamespace)
+	}
+	operatorConfig.SetOperatorNamespace()
 
 	printVersion()
 

--- a/api-operator/deploy/controller-artifacts/operator.yaml
+++ b/api-operator/deploy/controller-artifacts/operator.yaml
@@ -35,7 +35,7 @@ spec:
           # Replace this with the built image name
           image: wso2/k8s-api-operator:1.2.2
           command:
-          - api-operator
+            - api-operator
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
@@ -46,3 +46,5 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "api-operator"
+            - name: SYSTEM_NAMESPACE
+              value: "wso2-system"

--- a/api-operator/pkg/config/system.go
+++ b/api-operator/pkg/config/system.go
@@ -14,12 +14,32 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package ratelimiting
+package config
 
-const (
-	policyFileConst        = "policies.yaml"
-	policyConfMapNameConst = "policy-configmap"
-	resourceConst          = "Resource"
-	subscriptionConst      = "Subscription"
-	applicationConst       = "Application"
+import (
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	"os"
 )
+
+const DefaultSystemNamespace = "wso2-system"
+const SystemNamespaceEnv = "SYSTEM_NAMESPACE"
+
+var (
+	SystemNamespace   = DefaultSystemNamespace
+	OperatorNamespace = DefaultSystemNamespace
+)
+
+func SetSystemNamespaceFromEnv() (found bool) {
+	ns, found := os.LookupEnv(SystemNamespaceEnv)
+	if !found {
+		ns = DefaultSystemNamespace
+	}
+	SystemNamespace = ns
+	return
+}
+
+func SetOperatorNamespace() {
+	if ns, err := k8sutil.GetOperatorNamespace(); err == nil {
+		OperatorNamespace = ns
+	}
+}

--- a/api-operator/pkg/controller/api/api_controller.go
+++ b/api-operator/pkg/controller/api/api_controller.go
@@ -19,6 +19,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"github.com/wso2/k8s-api-operator/api-operator/pkg/config"
 	"strconv"
 	"strings"
 	"time"
@@ -157,25 +158,25 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 	operatorOwner, ownerErr := getOperatorOwner(&r.client)
 	if ownerErr != nil {
 		reqLogger.Info("Operator was not found. No owner will be set for the artifacts",
-			"operator_namespace", wso2NameSpaceConst)
+			"operator_namespace", config.OperatorNamespace)
 	}
 	userNamespace := instance.Namespace
 
 	//get configurations file for the controller
 	controlConf := k8s.NewConfMap()
-	errConf := k8s.Get(&r.client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: controllerConfName},
+	errConf := k8s.Get(&r.client, types.NamespacedName{Namespace: config.SystemNamespace, Name: controllerConfName},
 		controlConf)
 	//get docker registry configs
 	dockerRegistryConf := k8s.NewConfMap()
-	errRegConf := k8s.Get(&r.client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: dockerRegConfigs},
+	errRegConf := k8s.Get(&r.client, types.NamespacedName{Namespace: config.SystemNamespace, Name: dockerRegConfigs},
 		dockerRegistryConf)
 	//get ingress configs
 	ingressConf := k8s.NewConfMap()
-	errIngressConf := k8s.Get(&r.client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: ingressConfigs},
+	errIngressConf := k8s.Get(&r.client, types.NamespacedName{Namespace: config.SystemNamespace, Name: ingressConfigs},
 		ingressConf)
 	//get openshift configs
 	OpenshiftConf := k8s.NewConfMap()
-	errOpenshiftConf := k8s.Get(&r.client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: openShiftConfigs},
+	errOpenshiftConf := k8s.Get(&r.client, types.NamespacedName{Namespace: config.SystemNamespace, Name: openShiftConfigs},
 		OpenshiftConf)
 	confErrs := []error{errConf, errRegConf, errIngressConf, errOpenshiftConf}
 	for _, err := range confErrs {
@@ -486,9 +487,9 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 			}
 
 			kanikoArgs := k8s.NewConfMap()
-			err = k8s.Get(&r.client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: kanikoArgsConfigs}, kanikoArgs)
+			err = k8s.Get(&r.client, types.NamespacedName{Namespace: config.SystemNamespace, Name: kanikoArgsConfigs}, kanikoArgs)
 			if err != nil && errors.IsNotFound(err) {
-				reqLogger.Info("No kaniko-arguments config map is available in wso2-system namespace")
+				reqLogger.Info("No kaniko-arguments config map is available in system namespace", "namespace", config.SystemNamespace)
 			}
 
 			var kanikoJob *batchv1.Job
@@ -709,7 +710,7 @@ func setApiDependent(client *client.Client, api *wso2v1alpha1.API, ownerRef *[]m
 // getOperatorOwner returns the owner reference of the operator
 func getOperatorOwner(client *client.Client) (*[]metav1.OwnerReference, error) {
 	depFound := &appsv1.Deployment{}
-	errDeploy := k8s.Get(client, types.NamespacedName{Name: "api_operator", Namespace: wso2NameSpaceConst}, depFound)
+	errDeploy := k8s.Get(client, types.NamespacedName{Name: "api_operator", Namespace: config.OperatorNamespace}, depFound)
 	if errDeploy != nil {
 		var noOwner []metav1.OwnerReference
 		return &noOwner, errDeploy

--- a/api-operator/pkg/controller/api/constants.go
+++ b/api-operator/pkg/controller/api/constants.go
@@ -21,7 +21,6 @@ const (
 	kanikoArguments     = "kanikoArguments"
 	registryTypeConst   = "registryType"
 	repositoryNameConst = "repositoryName"
-	wso2NameSpaceConst  = "wso2-system"
 	controllerConfName  = "controller-config"
 	ingressConfigs      = "ingress-configs"
 	openShiftConfigs    = "route-configs"

--- a/api-operator/pkg/controller/ratelimiting/ratelimiting_controller.go
+++ b/api-operator/pkg/controller/ratelimiting/ratelimiting_controller.go
@@ -18,6 +18,7 @@ package ratelimiting
 
 import (
 	"context"
+	"github.com/wso2/k8s-api-operator/api-operator/pkg/config"
 
 	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
 
@@ -125,7 +126,8 @@ func (r *ReconcileRateLimiting) Reconcile(request reconcile.Request) (reconcile.
 	//gets the details of the operator as the owner
 	operatorOwner, ownerErr := getOperatorOwner(r)
 	if ownerErr != nil {
-		reqLogger.Info("Operator was not found in the " + wso2NameSpaceConst + " namespace. No owner will be set for the artifacts")
+		reqLogger.Info("Operator was not found in the operator namespace. No owner will be set for the artifacts",
+			"operator_namespace", config.OperatorNamespace)
 	}
 
 	// GENERATE POLICY YAML USING CRD INSTANCE
@@ -362,7 +364,7 @@ type Policy struct {
 func getOperatorOwner(r *ReconcileRateLimiting) ([]metav1.OwnerReference, error) {
 	depFound := &appsv1.Deployment{}
 	setOwner := true
-	deperr := r.client.Get(context.TODO(), types.NamespacedName{Name: "api-operator", Namespace: wso2NameSpaceConst}, depFound)
+	deperr := r.client.Get(context.TODO(), types.NamespacedName{Name: "api-operator", Namespace: config.OperatorNamespace}, depFound)
 	if deperr != nil {
 		noOwner := []metav1.OwnerReference{}
 		return noOwner, deperr

--- a/api-operator/pkg/controller/targetendpoint/constants.go
+++ b/api-operator/pkg/controller/targetendpoint/constants.go
@@ -16,9 +16,8 @@
 package targetendpoint
 
 const (
-	wso2NameSpaceConst = "wso2-system"
-	privateJet         = "privateJet"
-	serverless         = "serverless"
+	privateJet = "privateJet"
+	serverless = "serverless"
 
 	hpaConfigMapName        = "hpa-configs"
 	maxReplicasConfigKey    = "targetEndpointMaxReplicas"

--- a/api-operator/pkg/controller/targetendpoint/targetendpoint_controller.go
+++ b/api-operator/pkg/controller/targetendpoint/targetendpoint_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/sirupsen/logrus"
+	"github.com/wso2/k8s-api-operator/api-operator/pkg/config"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
 	"k8s.io/api/autoscaling/v2beta1"
 	"k8s.io/api/autoscaling/v2beta2"
@@ -133,7 +134,7 @@ func (r *ReconcileTargetEndpoint) Reconcile(request reconcile.Request) (reconcil
 		reqLogger.Info("Operator was not found in the " + instance.Namespace + " namespace. No owner will be set for the artifacts")
 	}
 	//get configurations file for the controller
-	controlConf, err := getConfigmap(r, "controller-config", "wso2-system")
+	controlConf, err := getConfigmap(r, "controller-config", config.SystemNamespace)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Controller configmap is not found, could have been deleted after reconcile request.
@@ -460,7 +461,7 @@ func createHPA(client *client.Client, targetEp *wso2v1alpha1.TargetEndpoint, dep
 	owner []metav1.OwnerReference) error {
 	// get global hpa configs, return error if not found (required config map)
 	hpaConfMap := k8s.NewConfMap()
-	err := k8s.Get(client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: hpaConfigMapName}, hpaConfMap)
+	err := k8s.Get(client, types.NamespacedName{Namespace: config.SystemNamespace, Name: hpaConfigMapName}, hpaConfMap)
 	if err != nil {
 		return err
 	}
@@ -495,7 +496,7 @@ func createHPAv2beta1(client *client.Client, targetEp *wso2v1alpha1.TargetEndpoi
 
 	// get global hpa configs, return error if not found (required config map)
 	hpaConfMap := k8s.NewConfMap()
-	err := k8s.Get(client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: hpaConfigMapName}, hpaConfMap)
+	err := k8s.Get(client, types.NamespacedName{Namespace: config.SystemNamespace, Name: hpaConfigMapName}, hpaConfMap)
 	if err != nil {
 		log.Error(err, "HPA configs not defined")
 		return nil, err
@@ -552,7 +553,7 @@ func createHPAv2beta2(client *client.Client, targetEp *wso2v1alpha1.TargetEndpoi
 
 	// get global hpa configs, return error if not found (required config map)
 	hpaConfMap := k8s.NewConfMap()
-	err := k8s.Get(client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: hpaConfigMapName}, hpaConfMap)
+	err := k8s.Get(client, types.NamespacedName{Namespace: config.SystemNamespace, Name: hpaConfigMapName}, hpaConfMap)
 	if err != nil {
 		return nil, err
 	}

--- a/api-operator/pkg/endpoints/sidecar.go
+++ b/api-operator/pkg/endpoints/sidecar.go
@@ -18,6 +18,7 @@ package endpoints
 
 import (
 	"errors"
+	"github.com/wso2/k8s-api-operator/api-operator/pkg/config"
 
 	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
@@ -101,7 +102,7 @@ func getResourceMetadata(client *client.Client,
 	targetEndpointCr *wso2v1alpha1.TargetEndpoint) (corev1.ResourceList, corev1.ResourceList, error) {
 	controllerConfMap := &corev1.ConfigMap{}
 	err := k8s.Get(client,
-		types.NamespacedName{Namespace: "wso2-system", Name: "controller-config"}, controllerConfMap)
+		types.NamespacedName{Namespace: config.SystemNamespace, Name: "controller-config"}, controllerConfMap)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/api-operator/pkg/mgw/api.go
+++ b/api-operator/pkg/mgw/api.go
@@ -18,6 +18,7 @@ package mgw
 
 import (
 	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
+	"github.com/wso2/k8s-api-operator/api-operator/pkg/config"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
@@ -107,7 +108,7 @@ func ExternalIP(client *client.Client, apiInstance *wso2v1alpha1.API, operatorMo
 // get hostAliases for the deployment
 func getHostAliases(client *client.Client) []corev1.HostAlias {
 	mgwDeploymentConfMap := k8s.NewConfMap()
-	errGetDeploy := k8s.Get(client, types.NamespacedName{Name: mgwDeploymentConfigMapName, Namespace: wso2NameSpaceConst},
+	errGetDeploy := k8s.Get(client, types.NamespacedName{Name: mgwDeploymentConfigMapName, Namespace: config.SystemNamespace},
 		mgwDeploymentConfMap)
 	if errGetDeploy != nil {
 		logEp.Error(errGetDeploy, "Error getting mgw deployment configs")

--- a/api-operator/pkg/mgw/config.go
+++ b/api-operator/pkg/mgw/config.go
@@ -17,6 +17,7 @@
 package mgw
 
 import (
+	"github.com/wso2/k8s-api-operator/api-operator/pkg/config"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/kaniko"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/str"
@@ -33,10 +34,9 @@ import (
 var logConf = log.Log.WithName("mgw.config")
 
 const (
-	apimConfName       = "apim-config"
-	apimSecretName     = "apim-secret"
-	mgwConfMustache    = "mgw-conf-mustache"
-	wso2NameSpaceConst = "wso2-system"
+	apimConfName    = "apim-config"
+	apimSecretName  = "apim-secret"
+	mgwConfMustache = "mgw-conf-mustache"
 
 	mgwConfGoTmpl      = "mgwConf.gotmpl"
 	mgwConfSecretConst = "mgw-conf"
@@ -64,7 +64,7 @@ const (
 	enableRealtimeMessageRetrievalConst = "enableRealtimeMessageRetrieval"
 	enableRequestValidationConst        = "enableRequestValidation"
 	enableResponseValidationConst       = "enableResponseValidation"
-	enabledEventhub						= "enabledEventhub"
+	enabledEventhub                     = "enabledEventhub"
 	logLevelConst                       = "logLevel"
 	httpPortConst                       = "httpPort"
 	httpsPortConst                      = "httpsPort"
@@ -133,7 +133,7 @@ type Configuration struct {
 	// validation
 	EnableRequestValidation  string
 	EnableResponseValidation string
-	EnabledEventhub			 string
+	EnabledEventhub          string
 
 	//basic authentication
 	BasicUsername string
@@ -248,7 +248,7 @@ var Configs = &Configuration{
 	// validation
 	EnableRequestValidation:  "false",
 	EnableResponseValidation: "false",
-	EnabledEventhub: 		  "false",
+	EnabledEventhub:          "false",
 
 	//basic authentication
 	BasicUsername: "admin",
@@ -303,7 +303,7 @@ var Configs = &Configuration{
 func SetApimConfigs(client *client.Client) error {
 	// get data from APIM configmap
 	apimConfig := k8s.NewConfMap()
-	errApim := k8s.Get(client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: apimConfName}, apimConfig)
+	errApim := k8s.Get(client, types.NamespacedName{Namespace: config.SystemNamespace, Name: apimConfName}, apimConfig)
 
 	if errApim != nil {
 		if errors.IsNotFound(errApim) {
@@ -315,7 +315,7 @@ func SetApimConfigs(client *client.Client) error {
 	}
 
 	apimSecret := k8s.NewSecret()
-	errorApimSecret := k8s.Get(client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: apimSecretName}, apimSecret)
+	errorApimSecret := k8s.Get(client, types.NamespacedName{Namespace: config.SystemNamespace, Name: apimSecretName}, apimSecret)
 
 	if errorApimSecret != nil {
 		if errors.IsNotFound(errorApimSecret) {
@@ -431,7 +431,7 @@ func SetApimConfigs(client *client.Client) error {
 func ApplyConfFile(client *client.Client, userNamespace, apiName string, owner *[]metav1.OwnerReference) error {
 	// retrieving the MGW template configmap
 	templateConfMap := k8s.NewConfMap()
-	errConf := k8s.Get(client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: mgwConfMustache}, templateConfMap)
+	errConf := k8s.Get(client, types.NamespacedName{Namespace: config.SystemNamespace, Name: mgwConfMustache}, templateConfMap)
 	if errConf != nil {
 		logConf.Error(errConf, "Error retrieving the MGW template configmap")
 		return errConf

--- a/api-operator/pkg/mgw/hpa.go
+++ b/api-operator/pkg/mgw/hpa.go
@@ -19,6 +19,7 @@ package mgw
 import (
 	"errors"
 	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
+	"github.com/wso2/k8s-api-operator/api-operator/pkg/config"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/autoscaling/v2beta1"
@@ -50,7 +51,7 @@ func HPA(client *client.Client, api *wso2v1alpha1.API, dep *appsv1.Deployment, o
 	*v2beta2.HorizontalPodAutoscaler) {
 	// get global hpa configs, return error if not found (required config map)
 	hpaConfMap := k8s.NewConfMap()
-	err := k8s.Get(client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: hpaConfigMapName}, hpaConfMap)
+	err := k8s.Get(client, types.NamespacedName{Namespace: config.SystemNamespace, Name: hpaConfigMapName}, hpaConfMap)
 	if err != nil {
 		logHpa.Error(err, "HPA configs not defined")
 		return nil, nil
@@ -127,7 +128,7 @@ func HPAv2beta2(api *wso2v1alpha1.API, dep *appsv1.Deployment, owner *[]metav1.O
 func ValidateHpaConfigs(client *client.Client) error {
 	// get global hpa configs, return error if not found (required config map)
 	hpaConfMap := k8s.NewConfMap()
-	err := k8s.Get(client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: hpaConfigMapName}, hpaConfMap)
+	err := k8s.Get(client, types.NamespacedName{Namespace: config.SystemNamespace, Name: hpaConfigMapName}, hpaConfMap)
 	if err != nil {
 		return err
 	}

--- a/api-operator/pkg/mgw/ingress.go
+++ b/api-operator/pkg/mgw/ingress.go
@@ -18,6 +18,7 @@ package mgw
 
 import (
 	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
+	"github.com/wso2/k8s-api-operator/api-operator/pkg/config"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,7 +47,7 @@ const (
 func ApplyIngressResource(client *client.Client, api *wso2v1alpha1.API, apiBasePathMap map[string]string, owner *[]metav1.OwnerReference) error {
 	logIng := loggerIng.WithValues("namespace", api.Namespace, "apiName", api.Name)
 	ingressConfMap := k8s.NewConfMap()
-	err := k8s.Get(client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: ingressConfigs}, ingressConfMap)
+	err := k8s.Get(client, types.NamespacedName{Namespace: config.SystemNamespace, Name: ingressConfigs}, ingressConfMap)
 	if err != nil {
 		logIng.Error(err, "Error retrieving ingress configmap", "name", ingressConfigs)
 		return err

--- a/api-operator/pkg/mgw/route.go
+++ b/api-operator/pkg/mgw/route.go
@@ -19,6 +19,7 @@ package mgw
 import (
 	routv1 "github.com/openshift/api/route/v1"
 	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
+	"github.com/wso2/k8s-api-operator/api-operator/pkg/config"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -51,7 +52,7 @@ func ApplyRouteResource(client *client.Client, api *wso2v1alpha1.API,
 	apiBasePathMap map[string]string, owner *[]metav1.OwnerReference) error {
 	logRoute := loggerRoute.WithValues("namespace", api.Namespace, "apiName", api.Name)
 	routeConfMap := k8s.NewConfMap()
-	errRoute := k8s.Get(client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: openShiftConfigs}, routeConfMap)
+	errRoute := k8s.Get(client, types.NamespacedName{Namespace: config.SystemNamespace, Name: openShiftConfigs}, routeConfMap)
 	if errRoute != nil {
 		logRoute.Error(errRoute, "Error retrieving route configmap")
 		return errRoute

--- a/api-operator/pkg/mgw/uservolumes.go
+++ b/api-operator/pkg/mgw/uservolumes.go
@@ -17,6 +17,7 @@
 package mgw
 
 import (
+	"github.com/wso2/k8s-api-operator/api-operator/pkg/config"
 	"strings"
 
 	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
@@ -60,9 +61,9 @@ func UserDeploymentVolume(client *client.Client, api *wso2v1alpha1.API) ([]corev
 	errGetDeploy := k8s.Get(client, types.NamespacedName{Name: mgwDeploymentConfigMapName, Namespace: api.Namespace},
 		mgwDeploymentConfMap)
 	if errGetDeploy != nil && errors.IsNotFound(errGetDeploy) {
-		logDeploy.Info("Get mgw deployment configs", "from namespace", wso2NameSpaceConst)
+		logDeploy.Info("Get mgw deployment configs", "from_namespace", config.SystemNamespace)
 		//retrieve mgw deployment configs from wso2-system namespace
-		err := k8s.Get(client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: mgwDeploymentConfigMapName},
+		err := k8s.Get(client, types.NamespacedName{Namespace: config.SystemNamespace, Name: mgwDeploymentConfigMapName},
 			mgwDeploymentConfMap)
 		if err != nil && !errors.IsNotFound(err) {
 			logDeploy.Error(err, "Error while reading user volumes config")

--- a/api-operator/pkg/mgw/virtualservice.go
+++ b/api-operator/pkg/mgw/virtualservice.go
@@ -19,6 +19,7 @@ package mgw
 import (
 	"errors"
 	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
+	"github.com/wso2/k8s-api-operator/api-operator/pkg/config"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
 	istioapi "istio.io/api/networking/v1alpha3"
 	istioclient "istio.io/client-go/pkg/apis/networking/v1alpha3"
@@ -152,7 +153,7 @@ func ValidateIstioConfigs(client *client.Client, api *wso2v1alpha1.API) (*IstioC
 	istioConfigs := &IstioConfigs{}
 
 	istioConfigMap := k8s.NewConfMap()
-	if err := k8s.Get(client, types.NamespacedName{Namespace: wso2NameSpaceConst, Name: istioConfMapName},
+	if err := k8s.Get(client, types.NamespacedName{Namespace: config.SystemNamespace, Name: istioConfMapName},
 		istioConfigMap); err != nil {
 		logVsc.Error(err, "Istio configs configmap is empty", "configmap", istioConfMapName,
 			"key", istioGatewayConfKey)

--- a/api-operator/pkg/registry/registry.go
+++ b/api-operator/pkg/registry/registry.go
@@ -19,6 +19,7 @@ package registry
 import (
 	"encoding/json"
 	"fmt"
+	operatorConfig "github.com/wso2/k8s-api-operator/api-operator/pkg/config"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/maps"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/registry/utils"
@@ -34,8 +35,6 @@ import (
 )
 
 var logger = log.Log.WithName("registry")
-
-const wso2NameSpaceConst = "wso2-system"
 
 type Type string
 
@@ -99,13 +98,13 @@ func IsImageExist(client *client.Client) (bool, error) {
 	// checks if the pull secret is available
 	regPullSecret := k8s.NewSecret()
 	err := k8s.Get(client, types.NamespacedName{Name: config.ImagePullSecrets[0].Name,
-		Namespace: wso2NameSpaceConst}, regPullSecret)
+		Namespace: operatorConfig.SystemNamespace}, regPullSecret)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			logger.Info("Registry pull secret is not found",
-				"secret_name", utils.DockerRegCredSecret, "namespace", wso2NameSpaceConst)
+				"secret_name", utils.DockerRegCredSecret, "namespace", operatorConfig.SystemNamespace)
 		} else {
-			logger.Info("Error retrieving docker credentials secret", "secret_name", utils.DockerRegCredSecret, "namespace", wso2NameSpaceConst)
+			logger.Info("Error retrieving docker credentials secret", "secret_name", utils.DockerRegCredSecret, "namespace", operatorConfig.SystemNamespace)
 		}
 		return false, err
 	}
@@ -168,7 +167,7 @@ func copyConfigVolumes(client *client.Client, namespace string) error {
 	// get object from wso2's system namespace and
 	// creates or replaces volumes in the given namespace
 	for name, object := range regVolumes {
-		fromNsName := types.NamespacedName{Namespace: wso2NameSpaceConst, Name: name}
+		fromNsName := types.NamespacedName{Namespace: operatorConfig.SystemNamespace, Name: name}
 		if err := k8s.Get(client, fromNsName, object); err != nil {
 			return err
 		}

--- a/api-operator/pkg/security/const.go
+++ b/api-operator/pkg/security/const.go
@@ -25,11 +25,10 @@ const (
 	jwtConst               = "JWT"
 	oauthConst             = "Oauth"
 	apiKeyConst            = "apiKey"
-	apiKeyIn			   = "header"
-	apiKeyName			   = "api_key"
+	apiKeyIn               = "header"
+	apiKeyName             = "api_key"
 )
 
 const (
-	defaultSecurity    = "default-security-jwt"
-	wso2NameSpaceConst = "wso2-system"
+	defaultSecurity = "default-security-jwt"
 )

--- a/api-operator/pkg/security/default.go
+++ b/api-operator/pkg/security/default.go
@@ -19,6 +19,7 @@ package security
 import (
 	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/cert"
+	"github.com/wso2/k8s-api-operator/api-operator/pkg/config"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/mgw"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -37,11 +38,11 @@ func Default(client *client.Client, apiNamespace string, owner *[]metav1.OwnerRe
 	//check default security already exist in user namespace
 	errGetSec := k8s.Get(client, types.NamespacedName{Name: defaultSecurity, Namespace: apiNamespace}, securityDefault)
 	if errGetSec != nil && errors.IsNotFound(errGetSec) {
-		logDef.Info("Get default-security", "from namespace", wso2NameSpaceConst)
+		logDef.Info("Get default-security", "from namespace", config.SystemNamespace)
 		//retrieve default-security from wso2-system namespace
-		errSec := k8s.Get(client, types.NamespacedName{Name: defaultSecurity, Namespace: wso2NameSpaceConst}, securityDefault)
+		errSec := k8s.Get(client, types.NamespacedName{Name: defaultSecurity, Namespace: config.SystemNamespace}, securityDefault)
 		if errSec != nil {
-			logDef.Error(errSec, "Error getting default security", "namespace", wso2NameSpaceConst)
+			logDef.Error(errSec, "Error getting default security", "namespace", config.SystemNamespace)
 			return nil, errSec
 		}
 		for _, defaultSecurityConf := range securityDefault.Spec.SecurityConfig {
@@ -50,7 +51,7 @@ func Default(client *client.Client, apiNamespace string, owner *[]metav1.OwnerRe
 			//check default certificate exists in user namespace
 			err := k8s.Get(client, types.NamespacedName{Name: defaultSecurityConf.Certificate, Namespace: apiNamespace}, defaultCert)
 			if err != nil && errors.IsNotFound(err) {
-				errCert := k8s.Get(client, types.NamespacedName{Name: defaultSecurityConf.Certificate, Namespace: wso2NameSpaceConst}, defaultCert)
+				errCert := k8s.Get(client, types.NamespacedName{Name: defaultSecurityConf.Certificate, Namespace: config.SystemNamespace}, defaultCert)
 				if errCert != nil {
 					return nil, errCert
 				}


### PR DESCRIPTION
## Purpose
Set system namespace with the environment variable: `SYSTEM_NAMESPACE`
Add new package `config` for global configs

## Tests
- Tested scenario 2 with `SYSTEM_NAMESPACE = foo-sys` namespace
- Tested scenario 6 without defining `SYSTEM_NAMESPACE` variable

## Approach
Get `SYSTEM_NAMESPACE` from environment variable and set it to `config.SystemNamespace` global variable with enabling to all other packages to access it.

Change `SYSTEM_NAMESPACE` in operator.yaml
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: api-operator
  namespace: wso2-system
spec:
  replicas: 1
  selector:
    matchLabels:
      name: api-operator
  template:
    metadata:
      labels:
        name: api-operator
    spec:
      serviceAccountName: api-operator
      containers:
        - name: api-operator
          # Replace this with the built image name
          image: wso2/k8s-api-operator:1.2.2
          command:
            - api-operator
          imagePullPolicy: Always
          env:
            - name: WATCH_NAMESPACE
              value: ""
            - name: POD_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
            - name: OPERATOR_NAME
              value: "api-operator"
            - name: SYSTEM_NAMESPACE
              value: "wso2-system"
```

## Related Issues
https://github.com/wso2/k8s-api-operator/issues/443