### PR TITLE
itterate through all api definition

### DIFF
--- a/api-operator/pkg/apim/deleteAPI.go
+++ b/api-operator/pkg/apim/deleteAPI.go
@@ -17,6 +17,8 @@
 package apim
 
 import (
+	"strings"
+
 	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/maps"
@@ -25,25 +27,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"strings"
 )
 
 var logDelete = log.Log.WithName("apim.delete")
 
 func DeleteImportedAPI(client *client.Client, instance *wso2v1alpha1.API) error {
-	inputConf := k8s.NewConfMap()
-	errInput := k8s.Get(client, types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}, inputConf)
-
-	if errInput != nil {
-		if errors.IsNotFound(errInput) {
-			logDelete.Info("API project or swagger not found")
-			return errInput
-		} else {
-			logDelete.Error(errInput, "Error retrieving API configs to import")
-			return errInput
-		}
-	}
-
 	apimConfig, errInput := getRESTAPIConfigs(client)
 	if errInput != nil {
 		if errors.IsNotFound(errInput) {
@@ -72,20 +60,35 @@ func DeleteImportedAPI(client *client.Client, instance *wso2v1alpha1.API) error 
 		return errToken
 	}
 
-	if inputConf.BinaryData != nil {
-		deleteErr := deleteAPIFromProject(inputConf, accessToken, publisherEndpoint)
-		if deleteErr != nil {
-			logDelete.Error(deleteErr, "Error when deleting the API using zip")
-			return deleteErr
+	//itterate throught all API definition.
+	for _, configMapName := range instance.Spec.Definition.SwaggerConfigmapNames {
+		inputConf := k8s.NewConfMap()
+		errInput := k8s.Get(client, types.NamespacedName{Namespace: instance.Namespace, Name: configMapName}, inputConf)
+
+		if errInput != nil {
+			if errors.IsNotFound(errInput) {
+				logDelete.Info("API project or swagger not found")
+				return errInput
+			} else {
+				logDelete.Error(errInput, "Error retrieving API configs to import")
+				return errInput
+			}
 		}
-	} else {
-		deleteErr := deleteAPIFromSwagger(inputConf, accessToken, publisherEndpoint)
-		if deleteErr != nil {
-			logDelete.Error(deleteErr, "Error when deleting the API using swagger")
-			return deleteErr
+
+		if inputConf.BinaryData != nil {
+			deleteErr := deleteAPIFromProject(inputConf, accessToken, publisherEndpoint)
+			if deleteErr != nil {
+				logDelete.Error(deleteErr, "Error when deleting the API using zip")
+				return deleteErr
+			}
+		} else {
+			deleteErr := deleteAPIFromSwagger(inputConf, accessToken, publisherEndpoint)
+			if deleteErr != nil {
+				logDelete.Error(deleteErr, "Error when deleting the API using swagger")
+				return deleteErr
+			}
 		}
 	}
-
 	return nil
 }
 

--- a/api-operator/pkg/apim/importAPI.go
+++ b/api-operator/pkg/apim/importAPI.go
@@ -42,19 +42,6 @@ var insecure = true
 
 // ImportAPI imports an API to APIM using either project zip or swagger
 func ImportAPI(client *client.Client, api *wso2v1alpha1.API) error {
-	inputConf := k8s.NewConfMap()
-	errInput := k8s.Get(client, types.NamespacedName{Namespace: api.Namespace, Name: api.Name}, inputConf)
-
-	if errInput != nil {
-		if errors.IsNotFound(errInput) {
-			logImport.Info("API project or swagger not found")
-			return errInput
-		} else {
-			logImport.Error(errInput, "Error retrieving API configs to import")
-			return errInput
-		}
-	}
-
 	apimConfig, errInput := getRESTAPIConfigs(client)
 	if errInput != nil {
 		if errors.IsNotFound(errInput) {
@@ -82,19 +69,35 @@ func ImportAPI(client *client.Client, api *wso2v1alpha1.API) error {
 		return errToken
 	}
 
-	if inputConf.BinaryData != nil {
-		logImport.Info("Importing API using project zip")
-		importErr := importAPIFromZip(inputConf, accessToken, publisherEndpoint)
-		if importErr != nil {
-			logImport.Error(importErr, "Error when importing the API using zip")
-			return importErr
+	//itterate throught all API definition.
+	for _, configMapName := range api.Spec.Definition.SwaggerConfigmapNames {
+		inputConf := k8s.NewConfMap()
+		errInput := k8s.Get(client, types.NamespacedName{Namespace: api.Namespace, Name: configMapName}, inputConf)
+
+		if errInput != nil {
+			if errors.IsNotFound(errInput) {
+				logImport.Info("API project or swagger not found")
+				return errInput
+			} else {
+				logImport.Error(errInput, "Error retrieving API configs to import")
+				return errInput
+			}
 		}
-	} else {
-		logImport.Info("Importing API using swagger")
-		importErr := importAPIFromSwagger(inputConf, accessToken, publisherEndpoint)
-		if importErr != nil {
-			logImport.Error(importErr, "Error when importing the API using swagger")
-			return importErr
+
+		if inputConf.BinaryData != nil {
+			logImport.Info("Importing API using project zip")
+			importErr := importAPIFromZip(inputConf, accessToken, publisherEndpoint)
+			if importErr != nil {
+				logImport.Error(importErr, "Error when importing the API using zip")
+				return importErr
+			}
+		} else {
+			logImport.Info("Importing API using swagger")
+			importErr := importAPIFromSwagger(inputConf, accessToken, publisherEndpoint)
+			if importErr != nil {
+				logImport.Error(importErr, "Error when importing the API using swagger")
+				return importErr
+			}
 		}
 	}
 


### PR DESCRIPTION
## Purpose
In the original PR a configMap with an API definition must use same name as API CRD itself. I added possibility to use different name for an API CRD and a configMap with Swagger.

## Approach
I use the SwaggerConfigNames array from the API class to iterate through all defined API in CRD

## Related PRs
#488