### PR TITLE
ability to configure JWK endpoint for JWT instead of certificate

### DIFF
--- a/api-operator/deploy/controller-configs/mgw_conf_mustache.yaml
+++ b/api-operator/deploy/controller-configs/mgw_conf_mustache.yaml
@@ -121,7 +121,11 @@ data:
       {{ if .AudiencePresent }}
       audience = "{{.Audience}}"
       {{ end }}
+      {{ if .JwksPresent }}
+      jwksURL = "{{.JwksURL}}"
+      {{ else }}
       certificateAlias = "{{.CertificateAlias}}"
+      {{ end }}
       # Validate subscribed APIs
       validateSubscription = {{.ValidateSubscription}}
     {{end}}

--- a/api-operator/deploy/crds/wso2.com_securities_crd.yaml
+++ b/api-operator/deploy/crds/wso2.com_securities_crd.yaml
@@ -71,6 +71,8 @@ spec:
                     type: boolean
                   validateSubscription:
                     type: boolean
+                  jwksURL:
+                    type: string  
                 type: object
               type: array
             type:

--- a/api-operator/go.sum
+++ b/api-operator/go.sum
@@ -1888,6 +1888,7 @@ k8s.io/apimachinery v0.18.2 h1:44CmtbmkzVDAhCpRVSiP2R5PPrC2RtlIv/MoB8xpdRA=
 k8s.io/apimachinery v0.18.2/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
 k8s.io/apimachinery v0.18.6 h1:RtFHnfGNfd1N0LeSrKCUznz5xtUP1elRGvHJbL3Ntag=
 k8s.io/apimachinery v0.18.6/go.mod h1:OaXp26zu/5J7p0f92ASynJa1pZo06YlV9fG7BoWbCko=
+k8s.io/apimachinery v0.19.4 h1:+ZoddM7nbzrDCp0T3SWnyxqf8cbWPT2fkZImoyvHUG0=
 k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad/go.mod h1:XPCXEwhjaFN29a8NldXA901ElnKeKLrLtREO9ZhFyhg=
 k8s.io/apiserver v0.0.0-20191122221311-9d521947b1e1/go.mod h1:RbsZY5zzBIWnz4KbctZsTVjwIuOpTp4Z8oCgFHN4kZQ=
 k8s.io/apiserver v0.15.7/go.mod h1:d5Dbyt588GbBtUnbx9fSK+pYeqgZa32op+I1BmXiNuE=

--- a/api-operator/pkg/apis/wso2/v1alpha1/security_types.go
+++ b/api-operator/pkg/apis/wso2/v1alpha1/security_types.go
@@ -73,6 +73,7 @@ type SecurityConfig struct {
 	Audience             string `json:"audience"`
 	ValidateSubscription bool   `json:"validateSubscription,omitempty"`
 	ValidateAllowedAPIs  bool   `json:"validateAllowedAPIs,omitempty"`
+	JwksURL              string `json:"jwksURL"`
 }
 
 func init() {

--- a/api-operator/pkg/mgw/config.go
+++ b/api-operator/pkg/mgw/config.go
@@ -190,6 +190,8 @@ type JwtTokenConfig struct {
 	Audience             string
 	ValidateSubscription bool
 	AudiencePresent      bool
+	JwksPresent          bool
+	JwksURL              string
 }
 
 type APIKeyTokenConfig struct {
@@ -224,6 +226,7 @@ var Configs = &Configuration{
 			Audience:             "http://org.wso2.apimgt/gateway",
 			ValidateSubscription: false,
 			AudiencePresent:      false,
+			JwksPresent:          false,
 		},
 	},
 


### PR DESCRIPTION
## Purpose
We want to use a JWK endpoint for a IdP public key instead of a secret with hardcoded certificate. It will allow us to easily rotate certificates in the IdP

## Goals
Ability to configure a JWK endpoint in Security CRD instead of a certificate.

## Approach
Added new attribute to the Security CRD. Than add certificate or JWK endpoint to microgw conf mustache

## Issue
#478 