### PR TITLE
Add envFrom support for the integration CRD

### DIFF
--- a/api-operator/deploy/crds/wso2.com_integrations_crd.yaml
+++ b/api-operator/deploy/crds/wso2.com_integrations_crd.yaml
@@ -1,19 +1,3 @@
-# Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-#
-# WSO2 Inc. licenses this file to you under the Apache License,
-# Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -154,6 +138,39 @@ spec:
                     type: object
                 required:
                 - name
+                type: object
+              type: array
+            envFrom:
+              description: List of environment variable references set for the integration.
+              items:
+                description: EnvFromSource represents the source of a set of ConfigMaps
+                properties:
+                  configMapRef:
+                    description: The ConfigMap to select from
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the ConfigMap must be defined
+                        type: boolean
+                    type: object
+                  prefix:
+                    description: An optional identifier to prepend to each key in
+                      the ConfigMap. Must be a C_IDENTIFIER.
+                    type: string
+                  secretRef:
+                    description: The Secret to select from
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret must be defined
+                        type: boolean
+                    type: object
                 type: object
               type: array
             image:

--- a/api-operator/pkg/apis/wso2/v1alpha1/integration_types.go
+++ b/api-operator/pkg/apis/wso2/v1alpha1/integration_types.go
@@ -38,6 +38,8 @@ type IntegrationSpec struct {
 	InboundPorts []int32 `json:"inboundPorts,omitempty"`
 	// List of environment variables to set for the integration.
 	Env []corev1.EnvVar `json:"env,omitempty"`
+	// List of environment variable references set for the integration.
+	EnvFrom []corev1.EnvFromSource `json:"envFrom,omitempty"`
 }
 
 // IntegrationStatus defines the observed state of Integration

--- a/api-operator/pkg/apis/wso2/v1alpha1/zz_generated.deepcopy.go
+++ b/api-operator/pkg/apis/wso2/v1alpha1/zz_generated.deepcopy.go
@@ -415,6 +415,13 @@ func (in *IntegrationSpec) DeepCopyInto(out *IntegrationSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.EnvFrom != nil {
+		in, out := &in.EnvFrom, &out.EnvFrom
+		*out = make([]v1.EnvFromSource, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/api-operator/pkg/controller/integration/integration_deployment.go
+++ b/api-operator/pkg/controller/integration/integration_deployment.go
@@ -84,6 +84,7 @@ func (r *ReconcileIntegration) deploymentForIntegration(m *wso2v1alpha1.Integrat
 						Name:            "micro-integrator",
 						Ports:           exposePorts,
 						Env:             m.Spec.Env,
+						EnvFrom: 	 m.Spec.EnvFrom,
 						ImagePullPolicy: corev1.PullAlways,
 					}},
 					ImagePullSecrets: imageSecrets,


### PR DESCRIPTION
## Purpose
> Add support of `configMapRef` and `secretRef` into the Integration CRD. 

Fixes: https://github.com/wso2/devstudio-tooling-ei/issues/1306