### PR TITLE
Remove global variables from registry package

### DIFF
--- a/api-operator/pkg/controller/api/api_controller.go
+++ b/api-operator/pkg/controller/api/api_controller.go
@@ -433,7 +433,7 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 			"Skipping kaniko job. Image specified in API CRD.")
 	} else {
 		// check if the image already exists
-		imageExist, errImage := registry.IsImageExist(&r.client)
+		imageExist, errImage := registry.IsImageExist(&r.client, mgwDockerImage)
 		if errImage != nil {
 			reqLogger.Info("Error finding the MGW image in registry. Continue with creating Kaniko job",
 				"mgw_docker_image", mgwDockerImage)
@@ -495,7 +495,7 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 			var kanikoJob *batchv1.Job
 			reqLogger.Info("Deploying the Kaniko job in cluster")
 			r.recorder.Event(instance, corev1.EventTypeNormal, "KanikoJob", "Deploying kaniko job.")
-			kanikoJob = kaniko.Job(instance, controlConfigData, kanikoArgs.Data[kanikoArguments], ownerRef)
+			kanikoJob = kaniko.Job(instance, controlConfigData, kanikoArgs.Data[kanikoArguments], ownerRef, mgwDockerImage)
 			if err := controllerutil.SetControllerReference(instance, kanikoJob, r.scheme); err != nil {
 				return reconcile.Result{}, err
 			}
@@ -552,7 +552,7 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 	if deployMgwRuntime {
 		reqLogger.Info("Deploying MGW runtime image")
 		// create MGW deployment in k8s cluster
-		mgwDeployment, errDeploy := mgw.Deployment(&r.client, instance, controlConfigData, ownerRef, sidecarContainers)
+		mgwDeployment, errDeploy := mgw.Deployment(&r.client, instance, controlConfigData, ownerRef, sidecarContainers, mgwDockerImage)
 		r.recorder.Event(instance, corev1.EventTypeNormal, "MGWRuntime",
 			fmt.Sprintf("Deploying MGW runtime: %s.", mgwDeployment.Name))
 		if errDeploy != nil {

--- a/api-operator/pkg/kaniko/job.go
+++ b/api-operator/pkg/kaniko/job.go
@@ -18,6 +18,8 @@ package kaniko
 
 import (
 	"context"
+	"strings"
+
 	"github.com/golang/glog"
 	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/registry"
@@ -27,7 +29,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"strings"
 )
 
 var logJob = log.Log.WithName("kaniko.job")
@@ -37,14 +38,14 @@ const (
 )
 
 // Job returns a kaniko job with mounted volumes
-func Job(api *wso2v1alpha1.API, controlConfigData map[string]string, kanikoArgs string, owner *[]metav1.OwnerReference) *batchv1.Job {
+func Job(api *wso2v1alpha1.API, controlConfigData map[string]string, kanikoArgs string, owner *[]metav1.OwnerReference, image registry.Image) *batchv1.Job {
 	rootUserVal := int64(0)
 	jobName := api.Name + "-kaniko"
 	if api.Spec.UpdateTimeStamp != "" {
 		jobName = jobName + "-" + api.Spec.UpdateTimeStamp
 	}
 
-	regConfig := registry.GetConfig()
+	regConfig := registry.GetImageConfig(image)
 	AddVolumes(&regConfig.Volumes, &regConfig.VolumeMounts)
 
 	kanikoImg := controlConfigData[kanikoImgConst]

--- a/api-operator/pkg/mgw/config.go
+++ b/api-operator/pkg/mgw/config.go
@@ -17,6 +17,9 @@
 package mgw
 
 import (
+	"strconv"
+	"strings"
+
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/config"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/kaniko"

--- a/api-operator/pkg/mgw/deployment.go
+++ b/api-operator/pkg/mgw/deployment.go
@@ -52,8 +52,8 @@ const (
 
 // Deployment returns a MGW deployment for the given API definition
 func Deployment(client *client.Client, api *wso2v1alpha1.API, controlConfigData map[string]string,
-	owner *[]metav1.OwnerReference, sidecarContainers []corev1.Container) (*appsv1.Deployment, error) {
-	regConfig := registry.GetConfig()
+	owner *[]metav1.OwnerReference, sidecarContainers []corev1.Container, img registry.Image) (*appsv1.Deployment, error) {
+	regConfig := registry.GetImageConfig(img)
 	labels := map[string]string{"app": api.Name}
 	liveDelay, _ := strconv.ParseInt(controlConfigData[livenessProbeInitialDelaySeconds], 10, 32)
 	livePeriod, _ := strconv.ParseInt(controlConfigData[livenessProbePeriodSeconds], 10, 32)

--- a/api-operator/pkg/registry/dockerhub.go
+++ b/api-operator/pkg/registry/dockerhub.go
@@ -18,46 +18,45 @@ package registry
 
 import (
 	"fmt"
+
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/registry/utils"
 	corev1 "k8s.io/api/core/v1"
 )
 
 const DockerHub Type = "DOCKER_HUB"
 
-// Docker Hub configs
-var dockerHub = &Config{
-	RegistryType: DockerHub,
-	VolumeMounts: []corev1.VolumeMount{
-		{
-			Name:      "reg-secret-volume",
-			MountPath: "/kaniko/.docker/",
-			ReadOnly:  true,
+func getDockerHubConfigFunc(repoName string, imgName string, tag string) *Config {
+	// Docker Hub configs
+	return &Config{
+		RegistryType: DockerHub,
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "reg-secret-volume",
+				MountPath: "/kaniko/.docker/",
+				ReadOnly:  true,
+			},
 		},
-	},
-	Volumes: []corev1.Volume{
-		{
-			Name: "reg-secret-volume",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: utils.DockerRegCredSecret,
-					Items: []corev1.KeyToPath{
-						{
-							Key:  utils.DockerConfigKeyConst,
-							Path: "config.json",
+		Volumes: []corev1.Volume{
+			{
+				Name: "reg-secret-volume",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: utils.DockerRegCredSecret,
+						Items: []corev1.KeyToPath{
+							{
+								Key:  utils.DockerConfigKeyConst,
+								Path: "config.json",
+							},
 						},
 					},
 				},
 			},
 		},
-	},
-	ImagePullSecrets: []corev1.LocalObjectReference{
-		{Name: utils.DockerRegCredSecret},
-	},
-}
-
-func getDockerHubConfigFunc(repoName string, imgName string, tag string) *Config {
-	dockerHub.ImagePath = fmt.Sprintf("%s/%s:%s", repoName, imgName, tag)
-	return dockerHub
+		ImagePullSecrets: []corev1.LocalObjectReference{
+			{Name: utils.DockerRegCredSecret},
+		},
+		ImagePath: fmt.Sprintf("%s/%s:%s", repoName, imgName, tag),
+	}
 }
 
 func init() {

--- a/api-operator/pkg/registry/gcr.go
+++ b/api-operator/pkg/registry/gcr.go
@@ -18,6 +18,7 @@ package registry
 
 import (
 	"fmt"
+
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/registry/utils"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -28,39 +29,38 @@ const SvcAccKeyMountPath = "/kaniko/.gcr/"
 const svcAccKeyVolume = "svc-acc-key-volume"
 
 // Google Container Registry Configs
-var gcr = &Config{
-	RegistryType: Gcr,
-	VolumeMounts: []corev1.VolumeMount{
-		{
-			Name:      svcAccKeyVolume,
-			MountPath: SvcAccKeyMountPath,
-			ReadOnly:  true,
+
+func getGcrConfigFunc(repoName string, imgName string, tag string) *Config {
+	return &Config{
+		RegistryType: Gcr,
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      svcAccKeyVolume,
+				MountPath: SvcAccKeyMountPath,
+				ReadOnly:  true,
+			},
 		},
-	},
-	Volumes: []corev1.Volume{
-		{
-			Name: svcAccKeyVolume,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: utils.GcrSvcAccKeySecret,
+		Volumes: []corev1.Volume{
+			{
+				Name: svcAccKeyVolume,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: utils.GcrSvcAccKeySecret,
+					},
 				},
 			},
 		},
-	},
-	Env: []corev1.EnvVar{
-		{
-			Name:  GoogleSecretEnvVariable,
-			Value: SvcAccKeyMountPath + utils.GcrSvcAccKeyFile,
+		Env: []corev1.EnvVar{
+			{
+				Name:  GoogleSecretEnvVariable,
+				Value: SvcAccKeyMountPath + utils.GcrSvcAccKeyFile,
+			},
 		},
-	},
-	ImagePullSecrets: []corev1.LocalObjectReference{
-		{Name: utils.GcrPullSecret},
-	},
-}
-
-func getGcrConfigFunc(repoName string, imgName string, tag string) *Config {
-	gcr.ImagePath = fmt.Sprintf("gcr.io/%s/%s:%s", repoName, imgName, tag)
-	return gcr
+		ImagePullSecrets: []corev1.LocalObjectReference{
+			{Name: utils.GcrPullSecret},
+		},
+		ImagePath: fmt.Sprintf("gcr.io/%s/%s:%s", repoName, imgName, tag),
+	}
 }
 
 func init() {

--- a/api-operator/pkg/registry/http.go
+++ b/api-operator/pkg/registry/http.go
@@ -18,28 +18,29 @@ package registry
 
 import (
 	"fmt"
-	"github.com/wso2/k8s-api-operator/api-operator/pkg/registry/utils"
 	"strings"
+
+	"github.com/wso2/k8s-api-operator/api-operator/pkg/registry/utils"
 )
 
 const HTTP Type = "HTTP"
 
-// Copy of Docker Hub configs as HTTP private registry configs
-var httpReg = *dockerHub
-
+// getHttpRegConfigFunc copies  Docker Hub configs as HTTP private registry configs
 func getHttpRegConfigFunc(repoName string, imgName string, tag string) *Config {
+	var httpReg = getDockerHubConfigFunc(repoName, imgName, tag)
+
 	httpReg.ImagePath = fmt.Sprintf("%s/%s:%s", repoName, imgName, tag)
 	// Add --insecure arg
 	// This will not effect Docker Hub configs since this is a copy of it
 	httpReg.Args = []string{"--insecure"}
 	// replace https with http and use default function
-	httpReg.IsImageExist = func(config *Config, auth utils.RegAuth, image string, tag string) (b bool, err error) {
+	httpReg.IsImageExist = func(config *Config, auth utils.RegAuth, imageRepository string, imageName string, tag string) (b bool, err error) {
 		auth.RegistryUrl = strings.Replace(auth.RegistryUrl, "https://", "http://", 1)
 		logger.Info("Checking for image in HTTP registry", "Registry URL", auth.RegistryUrl)
-		return utils.IsImageExists(auth, getImageWithoutReg(image), tag)
+		return utils.IsImageExists(auth, "", imageName, tag)
 	}
 
-	return &httpReg
+	return httpReg
 }
 
 func init() {

--- a/api-operator/pkg/registry/http.go
+++ b/api-operator/pkg/registry/http.go
@@ -37,7 +37,7 @@ func getHttpRegConfigFunc(repoName string, imgName string, tag string) *Config {
 	httpReg.IsImageExist = func(config *Config, auth utils.RegAuth, imageRepository string, imageName string, tag string) (b bool, err error) {
 		auth.RegistryUrl = strings.Replace(auth.RegistryUrl, "https://", "http://", 1)
 		logger.Info("Checking for image in HTTP registry", "Registry URL", auth.RegistryUrl)
-		return utils.IsImageExists(auth, "", imageName, tag)
+		return utils.IsImageExists(auth, getPathWithoutReg(repoName), imageName, tag)
 	}
 
 	return httpReg

--- a/api-operator/pkg/registry/https.go
+++ b/api-operator/pkg/registry/https.go
@@ -18,6 +18,7 @@ package registry
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/registry/utils"
 )
@@ -30,9 +31,15 @@ func getHttpsRegConfigFunc(repoName string, imgName string, tag string) *Config 
 	httpsReg.ImagePath = fmt.Sprintf("%s/%s:%s", repoName, imgName, tag)
 	httpsReg.IsImageExist = func(config *Config, auth utils.RegAuth, imageRepository string, imageName string, tag string) (b bool, err error) {
 		logger.Info("Checking for image in HTTPS registry", "Registry URL", auth.RegistryUrl)
-		return utils.IsImageExists(auth, "", imageName, tag)
+		return utils.IsImageExists(auth, getPathWithoutReg(repoName), imageName, tag)
 	}
 	return httpsReg
+}
+
+// getPathWithoutReg remove registry host name if it exists in the image path
+func getPathWithoutReg(image string) string {
+	splits := strings.Split(image, "/")
+	return strings.Join(splits[1:], "/")
 }
 
 func init() {

--- a/api-operator/pkg/registry/https.go
+++ b/api-operator/pkg/registry/https.go
@@ -18,35 +18,21 @@ package registry
 
 import (
 	"fmt"
+
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/registry/utils"
-	"strings"
 )
 
 const HTTPS Type = "HTTPS"
 
-// Copy of Docker Hub configs as HTTPS private registry configs
-var httpsReg = *dockerHub
-
+// getHttpsRegConfigFunc copies Docker Hub configs as HTTPS private registry configs
 func getHttpsRegConfigFunc(repoName string, imgName string, tag string) *Config {
+	var httpsReg = getDockerHubConfigFunc(repoName, imgName, tag)
 	httpsReg.ImagePath = fmt.Sprintf("%s/%s:%s", repoName, imgName, tag)
-	httpsReg.IsImageExist = func(config *Config, auth utils.RegAuth, image string, tag string) (b bool, err error) {
+	httpsReg.IsImageExist = func(config *Config, auth utils.RegAuth, imageRepository string, imageName string, tag string) (b bool, err error) {
 		logger.Info("Checking for image in HTTPS registry", "Registry URL", auth.RegistryUrl)
-		return utils.IsImageExists(auth, getImageWithoutReg(image), tag)
+		return utils.IsImageExists(auth, "", imageName, tag)
 	}
-	return &httpsReg
-}
-
-// getImageWithoutReg remove registry host name if it exists in the image name
-func getImageWithoutReg(image string) string {
-	splits := strings.Split(image, "/")
-	switch len(splits) {
-	case 3: // image in format "my-reg-host:5000/operator-demo/pets:v1"
-		return fmt.Sprintf("%s/%s", splits[1], splits[2])
-	case 2: // image in format "my-reg-host:5000/pets:v1"
-		return splits[1]
-	default:
-		return image
-	}
+	return httpsReg
 }
 
 func init() {

--- a/api-operator/pkg/registry/https_test.go
+++ b/api-operator/pkg/registry/https_test.go
@@ -1,0 +1,29 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/go-playground/assert/v2"
+)
+
+func TestGetPathWithoutReg(t *testing.T) {
+	datas :=
+		[]struct {
+			in  string
+			out string
+		}{
+			{
+				in:  "192.168.8.132:5000/apis-test",
+				out: "apis-test",
+			},
+			{
+				in:  "192.168.8.132:5000",
+				out: "",
+			},
+		}
+
+	for _, data := range datas {
+		result := getPathWithoutReg(data.in)
+		assert.Equal(t, result, data.out)
+	}
+}

--- a/api-operator/pkg/registry/quay.go
+++ b/api-operator/pkg/registry/quay.go
@@ -22,12 +22,11 @@ import (
 
 const QUAY Type = "QUAY"
 
-// Copy of Docker Hub configs as Quay registry configs
-var quayReg = *dockerHub
-
+// getQuayRegConfigFunc Copies Docker Hub configs as Quay registry configs
 func getQuayRegConfigFunc(repoName string, imgName string, tag string) *Config {
+	var quayReg = getDockerHubConfigFunc(repoName, imgName, tag)
 	quayReg.ImagePath = fmt.Sprintf("%s/%s:%s", repoName, imgName, tag)
-	return &quayReg
+	return quayReg
 }
 
 func init() {

--- a/api-operator/pkg/registry/utils/utils.go
+++ b/api-operator/pkg/registry/utils/utils.go
@@ -17,8 +17,10 @@
 package utils
 
 import (
-	registryclient "github.com/heroku/docker-registry-client/registry"
+	"fmt"
 	"net/url"
+
+	registryclient "github.com/heroku/docker-registry-client/registry"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
@@ -30,7 +32,8 @@ type RegAuth struct {
 	Password    string
 }
 
-func IsImageExists(auth RegAuth, image string, tag string) (bool, error) {
+func IsImageExists(auth RegAuth, imageRepository string, imageName string, tag string) (bool, error) {
+	image := fmt.Sprintf("%s/%s", imageRepository, imageName)
 	hub, err := registryclient.New(auth.RegistryUrl, auth.Username, auth.Password)
 	if err != nil {
 		logger.Error(err, "Error connecting to the docker registry", "registry-url", auth.RegistryUrl)


### PR DESCRIPTION
## Purpose

Because of global variables in the registry package, when the Operator restarts and several `API` resources exist, the operator will mix the image names between all APIs. As a result, all micro-gateways are deployed with the same image name (the one that was written last in the global variable)

I was able to test the case with  a GCR registry, but not with other registries.

Fixes #461 