### PR TITLE
Enable jaeger tracing from config

### DIFF
--- a/api-operator/deploy/controller-configs/controller_conf.yaml
+++ b/api-operator/deploy/controller-configs/controller_conf.yaml
@@ -102,6 +102,10 @@ data:
   enableResponseValidation: "false"
   # Enable configurations for retrieving API and subscription data from API Manager.
   enabledEventhub: "false"
+  #Enable Jaeger tracing
+  tracingEnabled: "false"
+  tracingJaegerPort: ""
+  tracingJaegerHost: ""
   #APIKey issuer configurations
   #APIKey STS token configurations
   enabledAPIKeyIssuer: "true"

--- a/api-operator/deploy/controller-configs/mgw_conf_mustache.yaml
+++ b/api-operator/deploy/controller-configs/mgw_conf_mustache.yaml
@@ -399,3 +399,13 @@ data:
     [b7a.observability.metrics.prometheus]
       port=9797
     {{ end }}
+
+    {{ if .TracingEnabled }}
+    [b7a.observability.tracing]
+      # Flag to enable Tracing
+      enabled = true
+      name = "jaeger"
+    [b7a.observability.tracing.jaeger.reporter]
+      port={{$.TracingJaegerPort}}
+      hostname="{{$.TracingJaegerHost}}"
+    {{ end }}

--- a/api-operator/pkg/mgw/config.go
+++ b/api-operator/pkg/mgw/config.go
@@ -93,6 +93,9 @@ const (
 	jwtTokenCacheExpiryTimeConst        = "jwtTokenCacheExpiryTime"
 	jwtTokenCacheCapacityConst          = "jwtTokenCacheCapacity"
 	jwtTokenCacheEvictionFactorConst    = "jwtTokenCacheEvictionFactor"
+	tracingEnabledConst                 = "tracingEnabled"
+	tracingJaegerPortConst              = "tracingJaegerPort"
+	tracingJaegerHostConst              = "tracingJaegerHost"
 )
 
 // Configuration represents configurations for MGW
@@ -166,6 +169,11 @@ type Configuration struct {
 
 	// enable observability of MGW
 	ObservabilityEnabled bool
+
+	// enable Tracing with Jaeger
+	TracingEnabled    bool
+	TracingJaegerPort int32
+	TracingJaegerHost string
 
 	// JWT Header Configs
 	JwtHeader string
@@ -290,6 +298,9 @@ var Configs = &Configuration{
 
 	// enable observability of MGW
 	ObservabilityEnabled: false,
+
+	//enable tracing of MGW with Jeager
+	TracingEnabled: false,
 
 	// JWT Header Configs
 	JwtHeader: "X-JWT-Assertion",
@@ -436,6 +447,16 @@ func SetApimConfigs(client *client.Client) error {
 		Configs.JwtTokenCacheEvictionFactor = jwtTokenCacheEvictionFactor
 	}
 
+	Configs.TracingEnabled = strings.EqualFold(apimConfig.Data[tracingEnabledConst], "true")
+	if Configs.TracingEnabled {
+		jaegerPort, err := strconv.Atoi(apimConfig.Data[tracingJaegerPortConst])
+		if err != nil {
+			logConf.Error(err, "Provided jaeger port is not valid.")
+		} else {
+			Configs.TracingJaegerPort = int32(jaegerPort)
+		}
+		Configs.TracingJaegerHost = apimConfig.Data[tracingJaegerHostConst]
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Purpose
Allow to configure if tracing is enabled in apim configuration. Currently only direct modification in mgw_conf-mustache can enable tracing.

## Goals
Allow to configure observability and tracing in the same way.