### PR TITLE
Virtual service update

### DIFF
--- a/api-operator/pkg/controller/api/api_controller.go
+++ b/api-operator/pkg/controller/api/api_controller.go
@@ -617,9 +617,9 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 
 		// creating Istio virtual service
 		if strings.EqualFold(operatorMode, istioMode) {
-			vtlSvc := mgw.IstioVirtualService(istioConfigs, instance, apiBasePathMap, *ownerRef)
-			if errVtlSvc := k8s.CreateIfNotExists(&r.client, vtlSvc); errVtlSvc != nil {
-				reqLogger.Error(errVtlSvc, "Error creating the Istio virtual service",
+			vtlSvc, errVtlSvc := mgw.ApplyIstioVirtualService(&r.client, istioConfigs, instance, apiBasePathMap, *ownerRef)
+			if errVtlSvc != nil {
+				reqLogger.Error(errVtlSvc, "Error creating the Istio virtual service2",
 					"virtual_service", vtlSvc)
 				return reconcile.Result{}, errVtlSvc
 			}


### PR DESCRIPTION
## Purpose
When the operator mode is ISTIO it creates ISTIO virtual service with match -> url -> prefix where prefix is from swagger where I have in base path something like /api/{version} when I update information in swagger and update CRD API everything is update except virtual service which already exists. Result is that ISTI can route requests only to previous version but MGW knows only updated version. 

