### PR TITLE
Add resource limits for API Operator

### DIFF
--- a/api-operator/deploy/controller-artifacts/operator.yaml
+++ b/api-operator/deploy/controller-artifacts/operator.yaml
@@ -41,6 +41,13 @@ spec:
           command:
             - api-operator
           imagePullPolicy: Always
+          resources:
+            requests:
+              memory: "250Mi"
+              cpu: "250m"
+            limits:
+              memory: "500Mi"
+              cpu: "500m"
           env:
             - name: WATCH_NAMESPACE
               value: ""


### PR DESCRIPTION
## Purpose
Add resource limits for API Operator
fixes https://github.com/wso2/k8s-api-operator/issues/522

```
resources:
    requests:
        memory: "250Mi"
        cpu: "250m"
    limits:
        memory: "500Mi"
        cpu: "500m"
```