### PR TITLE
Updated minikube url to be used in CURL command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This will deploy a pod and service for the sample service.
         >> minikube service products --url
         ```
         
-        The IP you receive from above output can be used as the "EXTERNAL_IP" in the following command.
+        The URL you receive from above output can be used to replace `http://<EXTERNAL_IP>:80` in the following CURL command.
     
     </p>
     </details>


### PR DESCRIPTION
## Purpose
README.md needs to get updated for minikube users.

## Goals
From `minikube service <svc_name> --url ` command, it outputs an url in a format `http:// <ip>:<node_port>` . This url needs to be replaced with the url used in the CURL command (Related to non-minikube users).

