### PR TITLE
Updated minikube url used in curl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This will deploy a pod and service for the sample service.
         >> minikube service products --url
         ```
         
-        The IP you receive from above output can be used as the "EXTERNAL_IP" in the following command.
+        The URL you receive from above output can be used to replace `http://<EXTERNAL_IP>:80` in the following CURL command.
     
     </p>
     </details>


### PR DESCRIPTION
## Purpose
README.md needs to be updated about minikube url used in CURL command. 

## Goals
No need of replacing <EXTERNAL_IP> with minikube output. We can use whole url to test the microservice.

## Related Issue
 #527