### PR TITLE
Added omitempty for SecurityConfig type

### DIFF
--- a/api-operator/deploy/crds/wso2.com_apis_crd.yaml
+++ b/api-operator/deploy/crds/wso2.com_apis_crd.yaml
@@ -1,37 +1,8 @@
-#Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-#
-# WSO2 Inc. licenses this file to you under the Apache License,
-# Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: apis.wso2.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.replicas
-    name: INITIAL-REPLICAS
-    type: integer
-  - JSONPath: .spec.mode
-    name: Mode
-    type: string
-  - JSONPath: .spec.apiEndPoint
-    name: ENDPOINT
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: wso2.com
   names:
     kind: API
@@ -39,110 +10,123 @@ spec:
     plural: apis
     singular: api
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: API is the Schema for the apis API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: APISpec defines the desired state of API
-          properties:
-            apiEndPoint:
-              type: string
-            definition:
-              description: Definition of the API.
-              properties:
-                interceptors:
-                  description: Interceptors for API. Default value "<empty>".
-                  properties:
-                    ballerina:
-                      description: Ballerina interceptors. Default value "<empty>".
-                      items:
-                        type: string
-                      type: array
-                    java:
-                      description: Java interceptors. Default value "<empty>".
-                      items:
-                        type: string
-                      type: array
-                  type: object
-                swaggerConfigmapNames:
-                  description: Array of config map names of swagger definitions for
-                    the API.
-                  items:
-                    type: string
-                  type: array
-                type:
-                  type: string
-              required:
-              - swaggerConfigmapNames
-              type: object
-            environmentVariables:
-              description: Environment variables to be added to the API deployment.
-                Default value "<empty>".
-              items:
-                type: string
-              type: array
-            image:
-              description: Docker image of the API to be deployed. If specified, ignores
-                the values of `UpdateTimeStamp`, `Override`. Uses the given image
-                for the deployment. Default value "<empty>".
-              type: string
-            ingressHostname:
-              description: Ingress Hostname that the API is being exposed. Default
-                value "<empty>".
-              type: string
-            mode:
-              description: Mode of the API. The mode from the swagger definition will
-                be overridden by this value. Supports "privateJet", "sidecar", "<empty>".
-                Default value "<empty>".
-              type: string
-            override:
-              description: Override the exiting API docker image. Default value "false".
-              type: boolean
-            replicas:
-              description: Replica count of the API.
-              type: integer
-            updateTimeStamp:
-              description: Update API definition creating a new docker image. Make
-                a rolling update to the existing API. with prefixing the timestamp
-                value. Default value "<empty>".
-              type: string
-            version:
-              description: Version of the API. The version from the swagger definition
-                will be overridden by this value. Default value "<empty>".
-              type: string
-          required:
-          - definition
-          - replicas
-          type: object
-        status:
-          description: APIStatus defines the observed state of API
-          properties:
-            replicas:
-              description: replicas field in the status sub-resource will define the
-                initial replica count allocated to the API.This will be the minimum
-                replica count for a single API
-              type: integer
-          required:
-          - replicas
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.replicas
+      name: INITIAL-REPLICAS
+      type: integer
+    - jsonPath: .spec.mode
+      name: Mode
+      type: string
+    - jsonPath: .spec.apiEndPoint
+      name: ENDPOINT
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: API is the Schema for the apis API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: APISpec defines the desired state of API
+            properties:
+              apiEndPoint:
+                type: string
+              definition:
+                description: Definition of the API.
+                properties:
+                  interceptors:
+                    description: Interceptors for API. Default value "<empty>".
+                    properties:
+                      ballerina:
+                        description: Ballerina interceptors. Default value "<empty>".
+                        items:
+                          type: string
+                        type: array
+                      java:
+                        description: Java interceptors. Default value "<empty>".
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  swaggerConfigmapNames:
+                    description: Array of config map names of swagger definitions
+                      for the API.
+                    items:
+                      type: string
+                    type: array
+                  type:
+                    type: string
+                required:
+                - swaggerConfigmapNames
+                type: object
+              environmentVariables:
+                description: Environment variables to be added to the API deployment.
+                  Default value "<empty>".
+                items:
+                  type: string
+                type: array
+              image:
+                description: Docker image of the API to be deployed. If specified,
+                  ignores the values of `UpdateTimeStamp`, `Override`. Uses the given
+                  image for the deployment. Default value "<empty>".
+                type: string
+              ingressHostname:
+                description: Ingress Hostname that the API is being exposed. Default
+                  value "<empty>".
+                type: string
+              mode:
+                description: Mode of the API. The mode from the swagger definition
+                  will be overridden by this value. Supports "privateJet", "sidecar",
+                  "<empty>". Default value "<empty>".
+                type: string
+              override:
+                description: Override the exiting API docker image. Default value
+                  "false".
+                type: boolean
+              replicas:
+                description: Replica count of the API.
+                type: integer
+              updateTimeStamp:
+                description: Update API definition creating a new docker image. Make
+                  a rolling update to the existing API. with prefixing the timestamp
+                  value. Default value "<empty>".
+                type: string
+              version:
+                description: Version of the API. The version from the swagger definition
+                  will be overridden by this value. Default value "<empty>".
+                type: string
+            required:
+            - definition
+            - replicas
+            type: object
+          status:
+            description: APIStatus defines the observed state of API
+            properties:
+              replicas:
+                description: replicas field in the status sub-resource will define
+                  the initial replica count allocated to the API.This will be the
+                  minimum replica count for a single API
+                type: integer
+            required:
+            - replicas
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/api-operator/deploy/crds/wso2.com_ratelimitings_crd.yaml
+++ b/api-operator/deploy/crds/wso2.com_ratelimitings_crd.yaml
@@ -1,20 +1,4 @@
-#Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-#
-# WSO2 Inc. licenses this file to you under the Apache License,
-# Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ratelimitings.wso2.com
@@ -26,101 +10,105 @@ spec:
     plural: ratelimitings
     singular: ratelimiting
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: RateLimiting is the Schema for the ratelimitings API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: RateLimitingSpec defines the desired state of RateLimiting
-          properties:
-            bandwidth:
-              description: Bandwidth is exported type in Ratelimiting Spec
-              properties:
-                dataAmount:
-                  type: string
-                dataUnit:
-                  type: string
-              required:
-              - dataAmount
-              - dataUnit
-              type: object
-            conditions:
-              description: Conditions is exported type in Ratelimiting Spec
-              properties:
-                headerCondition:
-                  description: HeaderCondition is exported type in Ratelimiting Spec
-                  properties:
-                    headerName:
-                      type: string
-                    headerValue:
-                      type: string
-                  required:
-                  - headerName
-                  - headerValue
-                  type: object
-                ipCondition:
-                  description: IPCondition is exported type in Ratelimiting Spec
-                  properties:
-                    endIp:
-                      type: string
-                    negation:
-                      type: boolean
-                    specificIp:
-                      type: string
-                    startIp:
-                      type: string
-                    type:
-                      type: string
-                  required:
-                  - endIp
-                  - negation
-                  - specificIp
-                  - startIp
-                  - type
-                  type: object
-              required:
-              - headerCondition
-              - ipCondition
-              type: object
-            description:
-              type: string
-            requestCount:
-              description: RequestCount is exported type in Ratelimiting Spec
-              properties:
-                limit:
-                  type: integer
-              required:
-              - limit
-              type: object
-            stopOnQuotaReach:
-              type: boolean
-            timeUnit:
-              type: string
-            type:
-              type: string
-            unitTime:
-              type: integer
-          required:
-          - requestCount
-          - timeUnit
-          - type
-          - unitTime
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: RateLimiting is the Schema for the ratelimitings API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RateLimitingSpec defines the desired state of RateLimiting
+            properties:
+              bandwidth:
+                description: Bandwidth is exported type in Ratelimiting Spec
+                properties:
+                  dataAmount:
+                    type: string
+                  dataUnit:
+                    type: string
+                required:
+                - dataAmount
+                - dataUnit
+                type: object
+              conditions:
+                description: Conditions is exported type in Ratelimiting Spec
+                properties:
+                  headerCondition:
+                    description: HeaderCondition is exported type in Ratelimiting
+                      Spec
+                    properties:
+                      headerName:
+                        type: string
+                      headerValue:
+                        type: string
+                    required:
+                    - headerName
+                    - headerValue
+                    type: object
+                  ipCondition:
+                    description: IPCondition is exported type in Ratelimiting Spec
+                    properties:
+                      endIp:
+                        type: string
+                      negation:
+                        type: boolean
+                      specificIp:
+                        type: string
+                      startIp:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - endIp
+                    - negation
+                    - specificIp
+                    - startIp
+                    - type
+                    type: object
+                required:
+                - headerCondition
+                - ipCondition
+                type: object
+              description:
+                type: string
+              requestCount:
+                description: RequestCount is exported type in Ratelimiting Spec
+                properties:
+                  limit:
+                    type: integer
+                required:
+                - limit
+                type: object
+              stopOnQuotaReach:
+                type: boolean
+              timeUnit:
+                type: string
+              type:
+                type: string
+              unitTime:
+                type: integer
+            required:
+            - bandwidth
+            - conditions
+            - description
+            - requestCount
+            - stopOnQuotaReach
+            - timeUnit
+            - type
+            - unitTime
+            type: object
+        type: object
     served: true
     storage: true

--- a/api-operator/deploy/crds/wso2.com_securities_crd.yaml
+++ b/api-operator/deploy/crds/wso2.com_securities_crd.yaml
@@ -1,31 +1,8 @@
-#Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-#
-# WSO2 Inc. licenses this file to you under the Apache License,
-# Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: securities.wso2.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.type
-    name: SECURITY_TYPE
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: AGE
-    type: date
   group: wso2.com
   names:
     kind: Security
@@ -33,63 +10,71 @@ spec:
     plural: securities
     singular: security
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: Security is the Schema for the securities API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: SecuritySpec defines the desired state of Security
-          properties:
-            securityConfig:
-              items:
-                properties:
-                  alias:
-                    type: string
-                  audience:
-                    type: string
-                  certificate:
-                    type: string
-                  credentials:
-                    type: string
-                  endpoint:
-                    type: string
-                  issuer:
-                    type: string
-                  validateAllowedAPIs:
-                    type: boolean
-                  validateSubscription:
-                    type: boolean
-                  jwksURL:
-                    type: string  
-                type: object
-              type: array
-            type:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                Important: Run "operator-sdk generate k8s" to regenerate code after
-                modifying this file Add custom validation using kubebuilder tags:
-                https://book.kubebuilder.io/beyond_basics/generating_crd.html'
-              type: string
-          required:
-          - type
-          type: object
-        status:
-          description: SecurityStatus defines the observed state of Security
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: SECURITY_TYPE
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Security is the Schema for the securities API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SecuritySpec defines the desired state of Security
+            properties:
+              securityConfig:
+                items:
+                  properties:
+                    alias:
+                      type: string
+                    audience:
+                      type: string
+                    certificate:
+                      type: string
+                    credentials:
+                      type: string
+                    endpoint:
+                      type: string
+                    issuer:
+                      type: string
+                    jwksURL:
+                      type: string
+                    validateAllowedAPIs:
+                      type: boolean
+                    validateSubscription:
+                      type: boolean
+                  type: object
+                type: array
+              type:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book.kubebuilder.io/beyond_basics/generating_crd.html'
+                type: string
+            required:
+            - securityConfig
+            - type
+            type: object
+          status:
+            description: SecurityStatus defines the observed state of Security
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}

--- a/api-operator/deploy/crds/wso2.com_targetendpoints_crd.yaml
+++ b/api-operator/deploy/crds/wso2.com_targetendpoints_crd.yaml
@@ -1,20 +1,4 @@
-#Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-#
-# WSO2 Inc. licenses this file to you under the Apache License,
-# Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: targetendpoints.wso2.com
@@ -26,94 +10,93 @@ spec:
     plural: targetendpoints
     singular: targetendpoint
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: TargetEndpoint is the Schema for the targetendpoints API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: TargetEndpointSpec defines the desired state of TargetEndpoint
-          properties:
-            applicationProtocol:
-              description: Protocol of the application. Supports "http" and "https".
-              type: string
-            deploy:
-              description: Deployment details.
-              properties:
-                cpuLimit:
-                  type: string
-                dockerImage:
-                  type: string
-                maxReplicas:
-                  format: int32
-                  type: integer
-                memoryLimit:
-                  type: string
-                minReplicas:
-                  format: int32
-                  type: integer
-                name:
-                  type: string
-                reqMemory:
-                  type: string
-                requestCPU:
-                  type: string
-              required:
-              - dockerImage
-              - name
-              type: object
-            mode:
-              description: Mode of the Target Endpoint. Supports "privateJet", "sidecar",
-                "serverless". Default value "privateJet"
-              type: string
-            ports:
-              description: List of optional ports of the target endpoint. First port
-                should be the port of the target endpoint which is referred in swagger
-                definition.
-              items:
-                description: Port represents ports of the Target Endpoint
-                properties:
-                  name:
-                    description: The name of this port within the service. This must
-                      be a DNS_LABEL. All ports within a ServiceSpec must have unique
-                      names.
-                    type: string
-                  port:
-                    description: The port that will be exposed by this service.
-                    format: int32
-                    type: integer
-                  targetPort:
-                    description: Port that is targeted to expose.
-                    format: int32
-                    type: integer
-                required:
-                - name
-                - port
-                - targetPort
-                type: object
-              type: array
-          required:
-          - applicationProtocol
-          - deploy
-          - ports
-          type: object
-        status:
-          description: TargetEndpointStatus defines the observed state of TargetEndpoint
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TargetEndpoint is the Schema for the targetendpoints API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TargetEndpointSpec defines the desired state of TargetEndpoint
+            properties:
+              applicationProtocol:
+                description: Protocol of the application. Supports "http" and "https".
+                type: string
+              deploy:
+                description: Deployment details.
+                properties:
+                  cpuLimit:
+                    type: string
+                  dockerImage:
+                    type: string
+                  maxReplicas:
+                    format: int32
+                    type: integer
+                  memoryLimit:
+                    type: string
+                  minReplicas:
+                    format: int32
+                    type: integer
+                  name:
+                    type: string
+                  reqMemory:
+                    type: string
+                  requestCPU:
+                    type: string
+                required:
+                - dockerImage
+                - name
+                type: object
+              mode:
+                description: Mode of the Target Endpoint. Supports "privateJet", "sidecar",
+                  "serverless". Default value "privateJet"
+                type: string
+              ports:
+                description: List of optional ports of the target endpoint. First
+                  port should be the port of the target endpoint which is referred
+                  in swagger definition.
+                items:
+                  description: Port represents ports of the Target Endpoint
+                  properties:
+                    name:
+                      description: The name of this port within the service. This
+                        must be a DNS_LABEL. All ports within a ServiceSpec must have
+                        unique names.
+                      type: string
+                    port:
+                      description: The port that will be exposed by this service.
+                      format: int32
+                      type: integer
+                    targetPort:
+                      description: Port that is targeted to expose.
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  - port
+                  - targetPort
+                  type: object
+                type: array
+            required:
+            - applicationProtocol
+            - deploy
+            - ports
+            type: object
+          status:
+            description: TargetEndpointStatus defines the observed state of TargetEndpoint
+            type: object
+        type: object
     served: true
     storage: true

--- a/api-operator/pkg/apis/wso2/v1alpha1/security_types.go
+++ b/api-operator/pkg/apis/wso2/v1alpha1/security_types.go
@@ -65,15 +65,15 @@ type SecurityList struct {
 }
 
 type SecurityConfig struct {
-	Certificate          string `json:"certificate"`
-	Alias                string `json:"alias"`
-	Endpoint             string `json:"endpoint"`
-	Credentials          string `json:"credentials"`
-	Issuer               string `json:"issuer"`
-	Audience             string `json:"audience"`
+	Certificate          string `json:"certificate,omitempty"`
+	Alias                string `json:"alias,omitempty"`
+	Endpoint             string `json:"endpoint,omitempty"`
+	Credentials          string `json:"credentials,omitempty"`
+	Issuer               string `json:"issuer,omitempty"`
+	Audience             string `json:"audience,omitempty"`
 	ValidateSubscription bool   `json:"validateSubscription,omitempty"`
 	ValidateAllowedAPIs  bool   `json:"validateAllowedAPIs,omitempty"`
-	JwksURL              string `json:"jwksURL"`
+	JwksURL              string `json:"jwksURL,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
## Purpose
Applying petstorejwt secret will get failed due to the missing parameter "omitempty" in some non-essential fields of type SecurityConfig

## Goals
Add "omitempty" for those non-essential fields of type SecurityConfig

## Related Issue
#226 