### PR TITLE
Operator Improvements

### DIFF
--- a/api-operator/deploy/controller-artifacts/operator.yaml
+++ b/api-operator/deploy/controller-artifacts/operator.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
         - name: api-operator
           # Replace this with the built image name
-          image: wso2/k8s-api-operator:1.2.2
+          image: benura123/k8s-api-operator:v1.2.5
           command:
             - api-operator
           imagePullPolicy: Always

--- a/api-operator/deploy/controller-configs/docker_registry_conf.yaml
+++ b/api-operator/deploy/controller-configs/docker_registry_conf.yaml
@@ -25,4 +25,4 @@ data:
   #docker repository name which the mgw image to be pushed.  eg->  repositoryName: docker.io/{USER_NAME of Docker Hub account}
   repositoryName: DOCKER_REPOSITORY_NAME
   #pull secret array
-  imagePullSecretName: docker-my-secret-pull
+  imagePullSecretName:

--- a/api-operator/deploy/controller-configs/docker_registry_conf.yaml
+++ b/api-operator/deploy/controller-configs/docker_registry_conf.yaml
@@ -25,4 +25,4 @@ data:
   #docker repository name which the mgw image to be pushed.  eg->  repositoryName: docker.io/{USER_NAME of Docker Hub account}
   repositoryName: DOCKER_REPOSITORY_NAME
   #pull secret array
-  imagePullSecretName:
+  imagePullSecretNames:

--- a/api-operator/deploy/controller-configs/docker_registry_conf.yaml
+++ b/api-operator/deploy/controller-configs/docker_registry_conf.yaml
@@ -23,4 +23,6 @@ data:
   #docker registry type which the mgw image to be pushed. supported types: DOCKER_HUB, AMAZON_ECR, GCR, HTTP.   Default->  registryType: DOCKER_HUB
   registryType: DOCKER_HUB
   #docker repository name which the mgw image to be pushed.  eg->  repositoryName: docker.io/{USER_NAME of Docker Hub account}
-  repositoryName: REPOSITORY_NAME_OF_DOCKER_REGISTRY
+  repositoryName: DOCKER_REPOSITORY_NAME
+  #pull secret array
+  imagePullSecretName: docker-my-secret-pull

--- a/api-operator/deploy/controller-configs/docker_registry_conf.yaml
+++ b/api-operator/deploy/controller-configs/docker_registry_conf.yaml
@@ -23,6 +23,6 @@ data:
   #docker registry type which the mgw image to be pushed. supported types: DOCKER_HUB, AMAZON_ECR, GCR, HTTP.   Default->  registryType: DOCKER_HUB
   registryType: DOCKER_HUB
   #docker repository name which the mgw image to be pushed.  eg->  repositoryName: docker.io/{USER_NAME of Docker Hub account}
-  repositoryName: DOCKER_REPOSITORY_NAME
+  repositoryName: benura123
   #pull secret array
-  imagePullSecretNames:
+  imagePullSecretNames: #docker-my-secret-pull, docker-my-secret-1

--- a/api-operator/pkg/apis/serving/v1alpha1/register.go
+++ b/api-operator/pkg/apis/serving/v1alpha1/register.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	// SchemeGroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: "serving.knative.dev", Version: "v1alpha1"}
+	SchemeGroupVersion = schema.GroupVersion{Group: "serving.knative.dev", Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}

--- a/api-operator/pkg/controller/api/api_controller.go
+++ b/api-operator/pkg/controller/api/api_controller.go
@@ -422,18 +422,6 @@ func (r *ReconcileAPI) Reconcile(request reconcile.Request) (reconcile.Result, e
 		return reconcile.Result{}, errReg
 	}
 
-	// //If push registry is set
-	// if dockerPushRegistryConf != nil {
-	// 	mgwDockerImage.RegistryType = registry.Type(dockerPushRegistryConf.Data[registryTypeConst])
-	// 	mgwDockerImage.RepositoryName = dockerPushRegistryConf.Data[repositoryNameConst]
-
-	// 	errReg := registry.SetRegistry(&r.client, userNamespace, mgwDockerImage)
-	// 	if errReg != nil {
-	// 		reqLogger.Error(errReg, "Error setting docker push registry", "docker_image", mgwDockerImage)
-	// 		return reconcile.Result{}, errReg
-	// 	}
-	// }
-
 	// if Spec.Image is supplied do not need to build the image (i.e. don't run kaniko job)
 	if instance.Spec.Image != "" {
 		reqLogger.Info("Image is specified in the in API CRD. Skipping the kaniko job")

--- a/api-operator/pkg/controller/api/constants.go
+++ b/api-operator/pkg/controller/api/constants.go
@@ -28,7 +28,7 @@ const (
 	kanikoArgsConfigs   = "kaniko-arguments"
 
 	dockerPushRegName        = "pushRegistryName"
-	imagePullSecretNameConst = "imagePullSecretName"
+	imagePullSecretNameConst = "imagePullSecretNames"
 
 	operatorModeConst             = "operatorMode"
 	istioMode                     = "Istio"

--- a/api-operator/pkg/kaniko/job.go
+++ b/api-operator/pkg/kaniko/job.go
@@ -68,6 +68,9 @@ func Job(api *wso2v1alpha1.API, controlConfigData map[string]string, kanikoArgs 
 		args = append(args, kanikoArguments...)
 	}
 
+	var secretArray []corev1.LocalObjectReference
+	secretArray = append(secretArray, regConfig.ImagePullSecrets...)
+
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            jobName,
@@ -98,7 +101,7 @@ func Job(api *wso2v1alpha1.API, controlConfigData map[string]string, kanikoArgs 
 					},
 					RestartPolicy:    "Never",
 					Volumes:          *JobVolume,
-					ImagePullSecrets: regConfig.ImagePullSecrets,
+					ImagePullSecrets: secretArray,
 				},
 			},
 		},

--- a/api-operator/pkg/registry/amazon_ecr.go
+++ b/api-operator/pkg/registry/amazon_ecr.go
@@ -34,6 +34,7 @@ const AwsCredFileVolume = "aws-credentials"
 const AwsCredFileMountPath = "/root/.aws/"
 
 func getAmazonEcrConfigFunc(repoName string, imgName string, tag string) *Config {
+
 	// Amazon ECR Configs
 	return &Config{
 		RegistryType: AmazonECR,

--- a/api-operator/pkg/registry/dockerhub.go
+++ b/api-operator/pkg/registry/dockerhub.go
@@ -27,6 +27,11 @@ const DockerHub Type = "DOCKER_HUB"
 
 func getDockerHubConfigFunc(repoName string, imgName string, tag string) *Config {
 	// Docker Hub configs
+
+	var pullSecretArray []corev1.LocalObjectReference
+
+	pullSecretArray = utils.GetPullSecrets(PullSecretDefined, DockerPullSecretName)
+
 	return &Config{
 		RegistryType: DockerHub,
 		VolumeMounts: []corev1.VolumeMount{
@@ -52,10 +57,8 @@ func getDockerHubConfigFunc(repoName string, imgName string, tag string) *Config
 				},
 			},
 		},
-		ImagePullSecrets: []corev1.LocalObjectReference{
-			{Name: DockerPullSecretName},
-		},
-		ImagePath: fmt.Sprintf("%s/%s:%s", repoName, imgName, tag),
+		ImagePullSecrets: pullSecretArray,
+		ImagePath:        fmt.Sprintf("%s/%s:%s", repoName, imgName, tag),
 	}
 }
 

--- a/api-operator/pkg/registry/gcr.go
+++ b/api-operator/pkg/registry/gcr.go
@@ -31,6 +31,11 @@ const svcAccKeyVolume = "svc-acc-key-volume"
 // Google Container Registry Configs
 
 func getGcrConfigFunc(repoName string, imgName string, tag string) *Config {
+
+	var pullSecretArray []corev1.LocalObjectReference
+
+	pullSecretArray = utils.GetPullSecrets(PullSecretDefined, utils.GcrPullSecret)
+
 	return &Config{
 		RegistryType: Gcr,
 		VolumeMounts: []corev1.VolumeMount{
@@ -56,10 +61,8 @@ func getGcrConfigFunc(repoName string, imgName string, tag string) *Config {
 				Value: SvcAccKeyMountPath + utils.GcrSvcAccKeyFile,
 			},
 		},
-		ImagePullSecrets: []corev1.LocalObjectReference{
-			{Name: utils.GcrPullSecret},
-		},
-		ImagePath: fmt.Sprintf("gcr.io/%s/%s:%s", repoName, imgName, tag),
+		ImagePullSecrets: pullSecretArray,
+		ImagePath:        fmt.Sprintf("gcr.io/%s/%s:%s", repoName, imgName, tag),
 	}
 }
 

--- a/api-operator/pkg/registry/registry.go
+++ b/api-operator/pkg/registry/registry.go
@@ -39,6 +39,8 @@ var logger = log.Log.WithName("registry")
 
 type Type string
 
+var PullSecretDefined string
+
 // Image defines a docker image
 type Image struct {
 	RegistryType   Type   // Type of the registry
@@ -48,6 +50,7 @@ type Image struct {
 }
 
 // Config defines the registry specific configurations
+// TODO: Introduce new 'ImagePush Secrets' field
 type Config struct {
 	RegistryType     Type                          // Type of the registry
 	ImagePath        string                        // Full image path to be pushed by the Kaniko Job

--- a/api-operator/pkg/registry/utils/utils.go
+++ b/api-operator/pkg/registry/utils/utils.go
@@ -71,7 +71,7 @@ func GetPullSecrets(pullSecretDef string, pullSecretName string) []corev1.LocalO
 		secret.Name = pullSecretName
 		pullSecretArray = append(pullSecretArray, secret)
 	default:
-		secretValues := strings.Split(strings.TrimSpace(pullSecretDef), ",")
+		secretValues := strings.Split(strings.TrimSpace(strings.ReplaceAll(pullSecretDef, " ", "")), ",")
 		for _, secretValue := range secretValues {
 			secret.Name = secretValue
 			pullSecretArray = append(pullSecretArray, secret)

--- a/api-operator/pkg/registry/utils/utils.go
+++ b/api-operator/pkg/registry/utils/utils.go
@@ -63,8 +63,6 @@ func IsImageExists(auth RegAuth, imageRepository string, imageName string, tag s
 }
 
 func GetPullSecrets(pullSecretDef string, pullSecretName string) []corev1.LocalObjectReference {
-	// var pullSecretDef = &PullSecretDefined
-	// var pushSecretDef = &registry.PushSecretDefned
 	var pullSecretArray = []corev1.LocalObjectReference{}
 	var secret = corev1.LocalObjectReference{}
 

--- a/api-operator/pkg/registry/utils/utils.go
+++ b/api-operator/pkg/registry/utils/utils.go
@@ -19,8 +19,10 @@ package utils
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	registryclient "github.com/heroku/docker-registry-client/registry"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
@@ -58,4 +60,25 @@ func IsImageExists(auth RegAuth, imageRepository string, imageName string, tag s
 		}
 	}
 	return false, nil
+}
+
+func GetPullSecrets(pullSecretDef string, pullSecretName string) []corev1.LocalObjectReference {
+	// var pullSecretDef = &PullSecretDefined
+	// var pushSecretDef = &registry.PushSecretDefned
+	var pullSecretArray = []corev1.LocalObjectReference{}
+	var secret = corev1.LocalObjectReference{}
+
+	switch pullSecretDef {
+	case "":
+		secret.Name = pullSecretName
+		pullSecretArray = append(pullSecretArray, secret)
+	default:
+		secretValues := strings.Split(strings.TrimSpace(pullSecretDef), ",")
+		for _, secretValue := range secretValues {
+			secret.Name = secretValue
+			pullSecretArray = append(pullSecretArray, secret)
+		}
+	}
+
+	return pullSecretArray
 }

--- a/api-operator/pkg/swagger/endpoints.go
+++ b/api-operator/pkg/swagger/endpoints.go
@@ -20,15 +20,16 @@ import (
 	"encoding/json"
 	errs "errors"
 	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
 	"github.com/getkin/kin-openapi/openapi3"
 	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
 	"github.com/wso2/k8s-api-operator/api-operator/pkg/k8s"
 	"k8s.io/apimachinery/pkg/types"
-	"net/url"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"strconv"
-	"strings"
 )
 
 var logEp = log.Log.WithName("swagger.endpoints")
@@ -167,7 +168,7 @@ func updateSwaggerWithProdEPs(client *client.Client, swaggerExtensions map[strin
 	prodEpStr := string(endpointJson)
 	// check if endpoint is a reference
 	if strings.EqualFold(prodEpStr[1:2], "#") {
-		swaggerExtensions[ProductionEndpointExtension] = prodEpStr[1:len(prodEpStr)-1]
+		swaggerExtensions[ProductionEndpointExtension] = prodEpStr[1 : len(prodEpStr)-1]
 		return nil
 	}
 
@@ -217,7 +218,7 @@ func processEndpoints(client *client.Client, endpointList []string,
 				sideCarEndpoints[prodEpVal] = true
 				updatedEndpoint.Urls[index] = sidecarUrl
 			} else if strings.EqualFold(mode, ServerLess) {
-				prodEpVal = fmt.Sprintf("%v://%v.%v.svc.cluster.local", protocol, prodEpVal, epNamespace)
+				prodEpVal = fmt.Sprintf("%v://%v.%v", protocol, prodEpVal, epNamespace)
 				updatedEndpoint.Urls[index] = prodEpVal
 			} else {
 				prodEpVal = fmt.Sprintf("%v://%v.%v:%v", protocol, prodEpVal, epNamespace, port)

--- a/scenarios/scenario-14/README.md
+++ b/scenarios/scenario-14/README.md
@@ -17,7 +17,7 @@
 #### Installing Knative
 
 Follow the document
-[Installing the Serving component (version v0.16)](https://knative.dev/v0.16-docs/install/any-kubernetes-cluster/#installing-the-serving-component)
+[Installing the Serving component (version v0.20.0)](https://knative.dev/docs/#installing-the-serving-component)
 with picking the networking layer as **Istio**. No need to follow the section "Installing the Eventing component" of the
 document.
 

--- a/scenarios/scenario-5/README.md
+++ b/scenarios/scenario-5/README.md
@@ -80,6 +80,7 @@ In this swagger definition, the security schema of the "petstore" service has be
         - First line of the output shows the location of the API project.
         - Import the API to API Manager deployment
             ```$xslt
+            >> apictl login k8s -k
             >> apictl import-api -f petstore-oauth -e k8s -k
             
             Output:


### PR DESCRIPTION
## Purpose
It's better to add separate secrets for pull and push scenarios. (Allow users to define pull secret names rather than hard coding it)

## Goals
Users can now define array of imagePullSecretNames in docker_registry_conf.yaml.

## Approach
- Add new field "imagePullSecretName" under` docker-registry-config` data section.
- Check the presence of this value. If it's empty then use the default secret name used for pushing, or else use the array of pull secret names for the configurations.

## Documentation
Needs to be updated.

## Related PRs
#487 
