### PR TITLE
Fix [apim-k8s-571] service is not updated when updating an existing deployment

### DIFF
--- a/api-operator/pkg/k8s/client.go
+++ b/api-operator/pkg/k8s/client.go
@@ -40,7 +40,6 @@ func Get(client *client.Client, namespacedName types.NamespacedName, obj runtime
 		logCnt.Error(err, "Error getting k8s object", "kind", kind, "key", namespacedName)
 		return err
 	}
-	logCnt.Info("Getting k8s object is success", "object", obj)
 	return nil
 }
 


### PR DESCRIPTION
Fixes: https://github.com/wso2/k8s-api-operator/issues/571

Approach: I faced issue [1], as we have a `-` in the service name. As a workaround, I get the existing service object, extract required parameters and update the service object created from the updated configs. 

Also removed an unwanted INFO level log that prints when reconsile loop hits. 

[1]. https://github.com/kubernetes/kubernetes/issues/36072

