### PR TITLE
Update MI container lifecycle to handle graceful shutdown

### DIFF
--- a/api-operator/pkg/controller/integration/constants.go
+++ b/api-operator/pkg/controller/integration/constants.go
@@ -55,4 +55,6 @@ const (
 	livenessProbeConfigKey = "livenessProbe"
 	readinessProbeConfigKey = "readinessProbe"
 
+	shutdownScriptPath = "${WSO2_SERVER_HOME}/bin/micro-integrator.sh stop"
+
 )

--- a/api-operator/pkg/controller/integration/integration_deployment.go
+++ b/api-operator/pkg/controller/integration/integration_deployment.go
@@ -117,6 +117,10 @@ func (r *ReconcileIntegration) deploymentForIntegration(config EIConfigNew) *app
 							Requests: request,
 						},
 
+						Lifecycle: &corev1.Lifecycle{
+							PreStop: getShutdownHandler(),
+						},
+
 						Env:             m.Spec.Env,
 						EnvFrom: 	 m.Spec.EnvFrom,
 						ImagePullPolicy: corev1.PullAlways,
@@ -227,4 +231,14 @@ func getReadinessProbe(config EIConfigNew) (corev1.Probe, error) {
 		}
 		return corev1.Probe{}, errors.New("probe: no readiness probe defined in configmap")
 	}
+}
+
+// Get shutdown handler specific to MI containers that handles graceful shutdown upon pod termination
+func getShutdownHandler() *corev1.Handler {
+	shutDownHandler := corev1.Handler{
+		Exec: &corev1.ExecAction{
+			Command: []string{"sh", "-c", shutdownScriptPath},
+		},
+	}
+	return &shutDownHandler
 }


### PR DESCRIPTION
## Purpose

Add a `preStop handler` to MI container lifecycle so that `stop.sh` script is called upon any container termination. 
Related documentation at K8s [1]. 

Fixes: https://github.com/wso2/k8s-api-operator/issues/577

[1]. https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/