### PR TITLE
Give capability to WSO2 API Operator to support volumeMounts

### DIFF
--- a/api-operator/deploy/controller-artifacts/operator.yaml
+++ b/api-operator/deploy/controller-artifacts/operator.yaml
@@ -32,7 +32,7 @@ spec:
       containers:
         - name: api-operator
           # Replace this with the built image name
-          image: wso2/k8s-api-operator:2.0.2
+          image: wso2/k8s-api-operator:2.0.3
           ports:
             - containerPort: 9445
           command:

--- a/api-operator/deploy/crds/wso2.com_integrations_crd.yaml
+++ b/api-operator/deploy/crds/wso2.com_integrations_crd.yaml
@@ -1,19 +1,3 @@
-# Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-#
-# WSO2 Inc. licenses this file to you under the Apache License,
-# Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -73,6 +57,17 @@ spec:
               deploySpec:
                 description: Specification related to deployment
                 properties:
+                  configmapDetails:
+                    items:
+                      properties:
+                        fileName:
+                          type: string
+                        mountPath:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
                   cpuLimit:
                     description: CPU limit of containers in the pod Default value
                       "<empty>".
@@ -201,6 +196,8 @@ spec:
                       Default value "<empty>".
                     format: int32
                     type: integer
+                  pullPolicy:
+                    type: string
                   readinessProbe:
                     description: ReadinessProbe for containers in the pod Default
                       value "<empty>".
@@ -366,7 +363,7 @@ spec:
                           type: object
                         fieldRef:
                           description: 'Selects a field of the pod: supports metadata.name,
-                            metadata.namespace, metadata.labels, metadata.annotations,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
                             spec.nodeName, spec.serviceAccountName, status.hostIP,
                             status.podIP, status.podIPs.'
                           properties:

--- a/api-operator/deploy/crds/wso2.com_integrations_crd.yaml
+++ b/api-operator/deploy/crds/wso2.com_integrations_crd.yaml
@@ -1,3 +1,18 @@
+# Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/api-operator/pkg/apis/wso2/v1alpha2/integration_types.go
+++ b/api-operator/pkg/apis/wso2/v1alpha2/integration_types.go
@@ -35,7 +35,7 @@ type IntegrationSpec struct {
 	// Auto scale spec
 	AutoScale AutoScale `json:"autoScale,omitempty"`
 	// Ports to expose
-	Expose Expose  `json:"expose,omitempty"`
+	Expose Expose `json:"expose,omitempty"`
 	// Docker image credentials if the Image is in private registry
 	ImagePullSecret string `json:"imagePullSecret,omitempty"`
 	// List of environment variables to set for the integration.
@@ -50,6 +50,9 @@ type DeploySpec struct {
 	// Default value "<empty>".
 	// +optional
 	MinReplicas int32 `json:"minReplicas,omitempty"`
+
+	ConfigMapDetails []ConfigMapDetails `json:"configmapDetails,omitempty"`
+
 	// Cpu request of containers in the pod
 	// Default value "<empty>".
 	// +optional
@@ -74,6 +77,8 @@ type DeploySpec struct {
 	// Default value "<empty>".
 	// +optional
 	ReadinessProbe corev1.Probe `json:"readinessProbe,omitempty"`
+
+	PullPolicy PullPolicy `json:"pullPolicy,omitempty"`
 }
 
 // AutoScale defines the properties related to Auto scaling of pods
@@ -86,6 +91,22 @@ type AutoScale struct {
 	// Default value "<empty>".
 	// +optional
 	MaxReplicas int32 `json:"maxReplicas,omitempty"`
+}
+type PullPolicy string
+
+const (
+	// PullAlways means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+	PullAlways PullPolicy = "Always"
+	// PullNever means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+	PullNever PullPolicy = "Never"
+	// PullIfNotPresent means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+	PullIfNotPresent PullPolicy = "IfNotPresent"
+)
+
+type ConfigMapDetails struct {
+	Name      string `json:"name,omitempty"`
+	MountPath string `json:"mountPath,omitempty"`
+	FileName  string `json:"fileName,omitempty"`
 }
 
 // Expose defines the ports needs to be exposed
@@ -104,7 +125,7 @@ type IntegrationStatus struct {
 	// Name of the created service in the Integration deployment
 	ServiceName string `json:"serviceName"`
 	// Status of the Integration deployment
-	Readiness   string `json:"readiness"`
+	Readiness string `json:"readiness"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/api-operator/pkg/controller/integration/integration_deployment.go
+++ b/api-operator/pkg/controller/integration/integration_deployment.go
@@ -112,15 +112,15 @@ func (r *ReconcileIntegration) deploymentForIntegration(config EIConfigNew) *app
 			},
 		)
 	}
-	pullPolicy := m.Spec.DeploySpec.PullPolicy
-	imagePullPolicy := corev1.PullAlways
-	switch {
-	case pullPolicy == "Always":
-		imagePullPolicy = corev1.PullAlways
-	case pullPolicy == "Never":
+	var imagePullPolicy corev1.PullPolicy
+
+	switch pullPolicy := m.Spec.DeploySpec.PullPolicy; pullPolicy {
+	case "Never":
 		imagePullPolicy = corev1.PullNever
-	case pullPolicy == "IfNotPresent":
+	case "IfNotPresent":
 		imagePullPolicy = corev1.PullIfNotPresent
+	default:
+		imagePullPolicy = corev1.PullAlways
 	}
 
 	deployment := &appsv1.Deployment{

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -23,14 +23,14 @@
     <parent>
         <groupId>org.wso2.apim</groupId>
         <artifactId>k8s-api-operator</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.apim</groupId>
     <artifactId>k8s-api-operator-distribution</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <name>API Operator For K8s Distribution</name>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.apim</groupId>
     <artifactId>k8s-api-operator</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <name>API Operator For K8s</name>
     <packaging>pom</packaging>
 
@@ -52,7 +52,7 @@
                     </executions>
                     <configuration>
                         <repository>${docker.repository}</repository>
-                        <tag>v${project.version}</tag>
+                        <tag>${project.version}</tag>
                         <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
                         <skip>false</skip>
                     </configuration>


### PR DESCRIPTION
## Purpose
Give capability to WSO2 API Operator to support volume mounts and also to change the ImagePullPolicy as well.

## Goals
Fixes: https://github.com/wso2-enterprise/wso2-apim-internal/issues/67
